### PR TITLE
fix free play mode select instrument and broken drag

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import { css } from '@sightread/flake'
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef } from 'react'
 import { ArrowDown, LoadingIcon } from '@/icons'
 import clsx from 'clsx'
+import { useWhenClickedOutside } from '@/hooks'
 
 const classes = css({
   root: {
@@ -111,24 +112,8 @@ export default function Select({
     onChange(val)
     toggleMenu()
   }
-  const handleClickAway = useCallback(
-    (e: MouseEvent) => {
-      if (!openMenu) {
-        return
-      }
-      if (e.target !== menuRef.current) {
-        setOpenMenu(false)
-      }
-    },
-    [setOpenMenu, openMenu],
-  )
 
-  useEffect(() => {
-    window.addEventListener('click', handleClickAway)
-    return () => {
-      window.removeEventListener('click', handleClickAway)
-    }
-  }, [handleClickAway])
+  useWhenClickedOutside(() => setOpenMenu(false), menuRef, [])
 
   return (
     <div className={clsx(classes.root, { [classes.rootError]: error }, classNames?.select)}>
@@ -136,14 +121,20 @@ export default function Select({
         value={!loading ? display(selected) : ''}
         type="text"
         className={clsx(classes.input, classNames?.select)}
-        onClick={toggleMenu}
+        onClick={(e) => {
+          e.stopPropagation()
+          toggleMenu()
+        }}
         readOnly
       />
       <ArrowDown
         width={15}
         height={15}
         className={clsx(classes.arrowIcon, { [classes.arrowRotated]: openMenu }, classNames?.icon)}
-        onClick={toggleMenu}
+        onClick={(e) => {
+          e.stopPropagation()
+          toggleMenu()
+        }}
       />
       {loading && (
         <LoadingIcon width={15} height={15} className={clsx(classes.loading, classNames?.icon)} />
@@ -164,7 +155,10 @@ export default function Select({
                 <div
                   key={option}
                   className={clsx(classes.option, classNames?.option)}
-                  onClick={() => handleSelect(option)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleSelect(option)
+                  }}
                 >
                   {format(option)}
                 </div>

--- a/src/features/SongVisualization/SongVisualizer.tsx
+++ b/src/features/SongVisualization/SongVisualizer.tsx
@@ -19,6 +19,7 @@ type CanvasRendererProps = {
   getTime: () => number
   constrictView?: boolean
   selectedRange?: { start: number; end: number }
+  disableTouchscroll?: boolean
 }
 
 function CanvasRenderer({
@@ -29,6 +30,7 @@ function CanvasRenderer({
   selectedRange,
   getTime,
   constrictView = true,
+  disableTouchscroll = false,
 }: CanvasRendererProps) {
   const { width, height, measureRef } = useSize()
   const ctxRef = useRef<CanvasRenderingContext2D>()
@@ -53,10 +55,10 @@ function CanvasRenderer({
     [width, height],
   )
 
-  const canvasRect = useMemo(
+  const canvasRect: DOMRect = useMemo(
     () => canvasRef.current?.getBoundingClientRect() ?? {},
-    [canvasRef, width, height],
-  )
+    [width, height],
+  ) as DOMRect
 
   useRAFLoop(() => {
     if (!ctxRef.current || !song) {
@@ -86,9 +88,9 @@ function CanvasRenderer({
     <div
       style={{ position: 'absolute', width: '100%', height: '100%', touchAction: 'none' }}
       ref={measureRef}
-      onPointerMove={(e) => touchscroll.handleMove(e.nativeEvent)}
-      onPointerDown={(e) => touchscroll.handleDown(e.nativeEvent)}
-      onPointerUp={(e) => touchscroll.handleUp(e.nativeEvent)}
+      onPointerMove={(e) => !disableTouchscroll && touchscroll.handleMove(e.nativeEvent)}
+      onPointerDown={(e) => !disableTouchscroll && touchscroll.handleDown(e.nativeEvent)}
+      onPointerUp={(e) => !disableTouchscroll && touchscroll.handleUp(e.nativeEvent)}
     >
       <canvas ref={setupCanvas} width={width} height={height} />
     </div>

--- a/src/features/pages/Freeplay/components/TopBar.tsx
+++ b/src/features/pages/Freeplay/components/TopBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Select } from '@/components'
-import { BpmDisplay } from '@/features/SongInputControls'
 import { formatInstrumentName } from '@/utils'
 import { gmInstruments, InstrumentName } from '@/features/synth'
 import { ArrowLeftIcon } from '@/icons'
@@ -70,13 +69,12 @@ export default function TopBar({ isError, isLoading, value, onChange }: TopBarPr
           }}
         />
       </div>
+      {/* TODO: what should go in the center here? its awkward space now. */}
       <div
         aria-label="center-items"
         className="nav-buttons"
         style={{ width: '33%', display: 'flex', justifyContent: 'center' }}
-      >
-        <BpmDisplay />
-      </div>
+      />
       <div
         aria-label="right-items"
         style={{

--- a/src/features/pages/Freeplay/index.tsx
+++ b/src/features/pages/Freeplay/index.tsx
@@ -68,6 +68,7 @@ export default function FreePlay() {
             handSettings={{ 1: { hand: 'right' } }}
             getTime={() => freePlayer.getTime()}
             constrictView={false}
+            disableTouchscroll={true}
           />
         </div>
       </div>

--- a/src/hooks/useWhenClickedOutside.ts
+++ b/src/hooks/useWhenClickedOutside.ts
@@ -3,7 +3,7 @@ import { useEffect, RefObject } from 'react'
 export default function useWhenClickedOutside(
   handleMouseEvent: (e: MouseEvent) => void,
   ref: RefObject<HTMLElement>,
-  deps: any[],
+  deps?: any[],
 ): void {
   useEffect(() => {
     function outsideClickHandler(e: MouseEvent) {


### PR DESCRIPTION
- disables dragging for free play since the concept doesn't make sense.
- fixes the `<select>` for instrument which wasn't opening. a `stopPropagation` worked.
- reuse `useWhenClickedOutside` for outside click detection
- Severely reduces the need for getBoundingClientRect calls during render loop