### PR TITLE
Migrate from @next/font --> next/font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@sightread/app",
       "version": "0.8.1",
       "dependencies": {
-        "@next/font": "13.2.4",
         "@preact/signals-react": "1.2.2",
         "@radix-ui/react-slider": "1.1.1",
         "@radix-ui/react-tooltip": "1.0.5",
@@ -330,11 +329,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.2.4.tgz",
-      "integrity": "sha512-lMAnuOYjv5g22WhD00u0DQ9u2rTMJH0S64PKE4Sy8Y2q+FJTYs6ZHT2z3VRoI8+AOWSLK4FirpnygcjOienQ9A=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "13.2.4",
@@ -5926,11 +5920,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.2.4.tgz",
-      "integrity": "sha512-lMAnuOYjv5g22WhD00u0DQ9u2rTMJH0S64PKE4Sy8Y2q+FJTYs6ZHT2z3VRoI8+AOWSLK4FirpnygcjOienQ9A=="
     },
     "@next/swc-android-arm-eabi": {
       "version": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "tsconfig-paths": "4.1.2"
   },
   "dependencies": {
-    "@next/font": "13.2.4",
     "@preact/signals-react": "1.2.2",
     "@radix-ui/react-slider": "1.1.1",
     "@radix-ui/react-tooltip": "1.0.5",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import type { AppProps } from 'next/app'
 import * as React from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { Inter } from '@next/font/google'
+import { Inter } from 'next/font/google'
 
 import * as analytics from '@/features/analytics'
 import { TooltipProvider } from '@radix-ui/react-tooltip'


### PR DESCRIPTION
```
warn  - Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead.
The `@next/font` package will be removed in Next.js 14. 
You can migrate by running `npx @next/codemod@latest built-in-next-font .`. 
Read more: https://nextjs.org/docs/messages/built-in-next-font
```