### PR TITLE
Fixes exception in wait mode when using sheet hero

### DIFF
--- a/src/features/player/index.ts
+++ b/src/features/player/index.ts
@@ -171,7 +171,7 @@ class Player {
     }
 
     let notes = []
-    const isWithinRange = (note: SongNote) => this.calcDiff(note.time, nextNote.time) <= GOOD_RANGE
+    const isWithinRange = (note: SongNote) => note && this.calcDiff(note.time, nextNote.time) <= GOOD_RANGE
     for (let i = this.currentIndex; isWithinRange(song.notes[i]); i++) {
       notes.push(song.notes[i])
     }


### PR DESCRIPTION
An out-of-bound exception is thrown in the following scenario:

- Playing Ode to Joy
- Right hand only
- Sheet hero
- Wait mode
- Reach the end of the song, and you can't continue as right before the last two notes, an exception is thrown

This PR prevents the error but does not fix the miscalculated `currentIndex`, which is likely to be used in other places and is the root cause of the exception.
