### PR TITLE
chore: remove npm install via bun

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: bun install
       - run: npm ci --include dev
       - run: npm run test
       - run: npm run build


### PR DESCRIPTION
I realised that bun install is the equivalent of
npm install.
For some reason I thought I needed that to install bun itself, but it doesn’t make sense to run bun commands…

Better to avoid any packages updates on CI, in case you also use that for the deployment.