### PR TITLE
Added missing velocity argument to playNote method within SynthStub class

### DIFF
--- a/src/features/synth/getSynth.ts
+++ b/src/features/synth/getSynth.ts
@@ -1,9 +1,9 @@
 import { isBrowser } from '@/utils'
-import midi from '../midi'
 import gmInstruments from './instruments'
-import { loadInstrument, soundfonts } from './loadInstrument'
-import { InstrumentName, SoundFont, Synth } from './types'
 import { getAudioContext, getKeyForSoundfont, isAudioContextEnabled } from './utils'
+import { SoundFont, Synth, InstrumentName } from './types'
+import { loadInstrument, soundfonts } from './loadInstrument'
+import midi from '../midi'
 
 function isValidInstrument(instrument: InstrumentName | undefined) {
   return instrument && gmInstruments.find((s) => s === instrument)

--- a/src/features/synth/getSynth.ts
+++ b/src/features/synth/getSynth.ts
@@ -1,9 +1,9 @@
 import { isBrowser } from '@/utils'
-import gmInstruments from './instruments'
-import { getAudioContext, getKeyForSoundfont, isAudioContextEnabled } from './utils'
-import { SoundFont, Synth, InstrumentName } from './types'
-import { loadInstrument, soundfonts } from './loadInstrument'
 import midi from '../midi'
+import gmInstruments from './instruments'
+import { loadInstrument, soundfonts } from './loadInstrument'
+import { InstrumentName, SoundFont, Synth } from './types'
+import { getAudioContext, getKeyForSoundfont, isAudioContextEnabled } from './utils'
 
 function isValidInstrument(instrument: InstrumentName | undefined) {
   return instrument && gmInstruments.find((s) => s === instrument)
@@ -49,7 +49,8 @@ class SynthStub implements Synth {
       this.synth.setMasterVolume(this.masterVolume)
     })
   }
-  playNote(note: number, velocity: number) {
+  playNote(note: number, velocity?: number) {
+    console.debug('called playnote in SynthStub')
     this.synth?.playNote(note, velocity)
   }
   stopNote(note: number) {
@@ -87,7 +88,7 @@ class InstrumentSynth implements Synth {
     this.masterVolume = 1
   }
 
-  playNote(note: number, velocity: number) {
+  playNote(note: number, velocity: number = 127 / 2) {
     midi.pressOutput(note, this.masterVolume)
     if (!isAudioContextEnabled()) {
       return

--- a/src/features/synth/getSynth.ts
+++ b/src/features/synth/getSynth.ts
@@ -49,8 +49,8 @@ class SynthStub implements Synth {
       this.synth.setMasterVolume(this.masterVolume)
     })
   }
-  playNote(note: number) {
-    this.synth?.playNote(note)
+  playNote(note: number, velocity: number) {
+    this.synth?.playNote(note, velocity)
   }
   stopNote(note: number) {
     this.synth?.stopNote(note)
@@ -87,7 +87,7 @@ class InstrumentSynth implements Synth {
     this.masterVolume = 1
   }
 
-  playNote(note: number, velocity = 127 / 2) {
+  playNote(note: number, velocity: number) {
     midi.pressOutput(note, this.masterVolume)
     if (!isAudioContextEnabled()) {
       return

--- a/src/features/synth/getSynth.ts
+++ b/src/features/synth/getSynth.ts
@@ -50,7 +50,6 @@ class SynthStub implements Synth {
     })
   }
   playNote(note: number, velocity?: number) {
-    console.debug('called playnote in SynthStub')
     this.synth?.playNote(note, velocity)
   }
   stopNote(note: number) {

--- a/src/features/synth/getSynth.ts
+++ b/src/features/synth/getSynth.ts
@@ -87,7 +87,7 @@ class InstrumentSynth implements Synth {
     this.masterVolume = 1
   }
 
-  playNote(note: number, velocity: number = 127 / 2) {
+  playNote(note: number, velocity = 127 / 2) {
     midi.pressOutput(note, this.masterVolume)
     if (!isAudioContextEnabled()) {
       return


### PR DESCRIPTION
While playing around with the app using my piano I realized that the app wasn't picking up the velocity of the keynotes. 

After some research and tinkering with the code I found out that the velocity was simply not being passed into the `playNote` method within `SynthStub `class, so I just added the velocity back as an argument.


