### PR TITLE
auto infer percussion soundfont for drums

### DIFF
--- a/src/features/parsers/parseMidi.ts
+++ b/src/features/parsers/parseMidi.ts
@@ -29,8 +29,8 @@ export default function parseMidi(midiData: ArrayBufferLike): Song {
         i,
         {
           name: track.name,
-          // infer percussion soundfont for drums
-          instrument: (track?.instrument?.family === 'drums' ? 'percussion' : track.instrument.name),
+          // infer percussion soundfont for drums (channel 9)
+          instrument: (track.channel === 9 ? 'percussion' : track.instrument.name),
           program: track.instrument.number,
         },
       ]

--- a/src/features/parsers/parseMidi.ts
+++ b/src/features/parsers/parseMidi.ts
@@ -29,7 +29,8 @@ export default function parseMidi(midiData: ArrayBufferLike): Song {
         i,
         {
           name: track.name,
-          instrument: track.instrument.name,
+          // infer percussion soundfont for drums
+          instrument: (track?.instrument?.family === 'drums' ? 'percussion' : track.instrument.name),
           program: track.instrument.number,
         },
       ]


### PR DESCRIPTION
It would be nice to automatic set the percussion soundfont for drums. Thanks to toneJS, we can detect that based on family as `drums`.

I tested with 2 midi files, and worked pretty well. I made a simple midi here, in case you would like to test it out.
[Simple Rock.mid.zip](https://github.com/user-attachments/files/16412913/Simple.Rock.mid.zip)

