### PR TITLE
Implementation of playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "clsx": "2.1.0",
     "jotai": "2.7.2",
     "jotai-effect": "1.0.0",
+    "m3u8-parser": "^7.2.0",
     "next": "14.1.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/songs/components/Playlists/PlaylistTable.tsx
+++ b/src/app/songs/components/Playlists/PlaylistTable.tsx
@@ -1,0 +1,51 @@
+import { Playlist, SongMetadata } from "@/types";
+import { Trash, ChevronRight, ChevronDown } from '@/icons'
+import clsx from 'clsx'
+import { formatTime } from '@/utils'
+import { Table } from '../../components'
+import './style.css';
+
+export default function PlayListTable({ playlist, onDelete }: { playlist: Playlist, onDelete: ()=> void }) {
+    return <details>
+        <summary className="mx-auto flex flex-grow">
+        <ChevronRight width={20} height={20} className="self-center details-mark-close"/>
+        <ChevronDown width={20} height={20} className="self-center details-mark-open"/>
+            <h2 className="flex-grow self-center fontleading-6 flex gap-2 whitespace-nowrap text-base font-medium text-foreground">{playlist.name}</h2>
+            <button className={clsx(
+                'hidden flex-nowrap whitespace-nowrap sm:flex',
+                'items-center gap-1 rounded-md px-4 py-2',
+                'bg-purple-dark text-white transition hover:bg-purple-hover',
+            )}
+            type="button"
+            onClick={(e)=>{
+                e.preventDefault()
+                e.stopPropagation()
+                onDelete()
+            }}
+            >
+                <Trash width={20} height={20} />
+            </button>
+        </summary>
+        <div className="mx-auto flex w-full max-w-screen-lg flex-grow flex-col p-2 min-h-40">
+        <Table
+            columns={[
+            { label: 'Title', id: 'title', keep: true },
+            {
+                label: 'Length',
+                id: 'duration',
+                format: (n) => formatTime(Number(n)),
+            }
+            ]}
+            getId={(s: SongMetadata) => s.id}
+            rows={playlist.songs}
+            onSelectRow={()=>{}}
+            search={''}
+            filter={['title', 'artist']}
+        />
+        {
+            !playlist.songs.length && (<p>No songs on playlist</p>)
+        }
+        </div>
+
+    </details>
+}

--- a/src/app/songs/components/Playlists/PlaylistsView.tsx
+++ b/src/app/songs/components/Playlists/PlaylistsView.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { Sizer } from '@/components'
+import { useRefreshStorageMetadata } from '@/features/data/library'
+import { savePlaylist, getPlaylistLibrary, deletePlaylist } from '@/features/persist'
+import clsx from 'clsx'
+import { useEffect, useState } from 'react'
+import { Plus } from '@/icons'
+import PlayListTable from './PlaylistTable'
+import { Playlist } from '@/types'
+
+export default function PlayListView({ onClose }: { onClose: () => void }) {
+  const refreshStorage = useRefreshStorageMetadata()
+  const [error, setError] = useState<string | null>(null);
+  const [playlists, setPlayLists] = useState<Playlist[]>([]);
+
+  useEffect(()=>refreshPlayLists(), []);
+
+  const refreshPlayLists = () => {
+    setPlayLists(getPlaylistLibrary());
+  };
+
+  const handleAddFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const target = e.target
+    if (target.files) {
+      try {
+        setError(null)
+        await savePlaylist(target.files[0]);
+        refreshStorage()
+        refreshPlayLists()
+      } catch (error: any) {
+        console.error('Something went wrong', error)
+        setError(error.message)
+      }
+    }
+    e.target.value = '';
+  }
+
+  const handleDelete = (playlist: Playlist) => {
+    if(confirm(`Are you sure you want to delete the playlist ${playlist.name}?`)){
+      deletePlaylist(playlist.id)
+      refreshStorage()
+      refreshPlayLists()
+    }
+  }
+
+  return (
+    <div
+      className="relative flex w-[min(100vw,500px)] flex-col gap-5 p-8 text-base"
+    >
+      <div className="flex flex-wrap items-baseline gap-2">
+        <h1 className="text-3xl font-bold">Playlists</h1>
+        <div className='flex-grow'></div>
+        <label htmlFor="file" className="self-center">
+          <div
+            className={clsx(
+              'hidden flex-nowrap whitespace-nowrap sm:flex',
+              'items-center gap-1 rounded-md px-4 py-2',
+              'bg-purple-dark text-white transition hover:bg-purple-hover',
+            )}
+          >
+            <Plus width={20} height={20} />
+            <span>Add New</span>
+          </div>
+        </label>
+        <input
+          onChange={handleAddFile}
+          id="file"
+          name="file"
+          type="file"
+          accept=".m3u8, .m3u"
+          className="hidden"
+        />
+        <div className='w-2'></div>
+      </div>
+      {error && (
+        <>
+          <Sizer height={24} />
+          <div
+            aria-label="Error message"
+            className="m-auto max-w-sm border-[#f5c6cb] bg-[#f8d7da] p-6 text-red-900"
+          >
+            {error}
+          </div>
+        </>
+      )}
+      {!playlists.length && (<p>No playlists found</p>)}
+      {playlists.map(playlist=>
+        (<PlayListTable key={playlist.id} playlist={playlist} onDelete={()=>handleDelete(playlist)}></PlayListTable>)
+      )}
+    </div>
+  )
+}

--- a/src/app/songs/components/Playlists/style.css
+++ b/src/app/songs/components/Playlists/style.css
@@ -1,0 +1,12 @@
+details .details-mark-close{
+    display:block;
+}
+details .details-mark-open{
+    display: none;
+}
+details[open] .details-mark-close{
+    display: none;
+}
+details[open] .details-mark-open{
+    display: block;
+}

--- a/src/app/songs/index.tsx
+++ b/src/app/songs/index.tsx
@@ -4,7 +4,7 @@ import { AppBar, MarketingFooter, Modal, Sizer } from '@/components'
 import { midishareMetadataAtom, useSongManifest } from '@/features/data/library'
 import { SongPreviewModal } from '@/features/SongPreview'
 import { useEventListener } from '@/hooks'
-import { Plus } from '@/icons'
+import { Plus, Archive } from '@/icons'
 import { DifficultyLabel, SongMetadata } from '@/types'
 import { formatTime } from '@/utils'
 import clsx from 'clsx'
@@ -14,6 +14,7 @@ import * as React from 'react'
 import { useState } from 'react'
 import { Table, UploadForm } from './components'
 import { SearchBox } from './components/Table/SearchBox'
+import PlayListView from './components/Playlists/PlaylistsView'
 
 export const metadata: Metadata = {
   title: 'Sightread: Select a song',
@@ -41,6 +42,7 @@ function getDifficultyLabel(s: number): DifficultyLabel {
 export default function SelectSongPage({ midishareMetadata }: any) {
   const songs = useSongManifest()
   const [isUploadFormOpen, setUploadForm] = useState<boolean>(false)
+  const [isPlaylistFormOpen, setPlaylistFormOpen] = useState<boolean>(false)
   const [selectedSongId, setSelectedSongId] = useState<any>('')
   const selectedSongMeta = songs.find((s) => s.id === selectedSongId)
   const [search, setSearch] = useState('')
@@ -61,6 +63,15 @@ export default function SelectSongPage({ midishareMetadata }: any) {
     setUploadForm(false)
   }
 
+  const handlePlaylists = (e: any) => {
+    setPlaylistFormOpen(true)
+    e.stopPropagation();
+  }
+
+  const handleClosePlaylists = () => {
+    setPlaylistFormOpen(false)
+  }
+
   return (
     <>
       <SongPreviewModal
@@ -72,6 +83,9 @@ export default function SelectSongPage({ midishareMetadata }: any) {
       />
       <Modal show={isUploadFormOpen} onClose={handleCloseAddNew}>
         <UploadForm onClose={handleCloseAddNew} />
+      </Modal>
+      <Modal show={isPlaylistFormOpen} onClose={handleClosePlaylists}>
+        <PlayListView onClose={handleCloseAddNew} />
       </Modal>
       <div className="flex h-screen w-full flex-col bg-purple-lightest">
         <AppBar />
@@ -92,6 +106,17 @@ export default function SelectSongPage({ midishareMetadata }: any) {
             >
               <Plus width={20} height={20} />
               <span>Add New</span>
+            </button>
+            <button
+              className={clsx(
+                'hidden flex-nowrap whitespace-nowrap sm:flex',
+                'items-center gap-1 rounded-md px-4 py-2',
+                'bg-purple-dark text-white transition hover:bg-purple-hover',
+              )}
+              onClick={handlePlaylists}
+            >
+              <Archive width={20} height={20} />
+              <span>Manage playlists</span>
             </button>
           </div>
           <Sizer height={32} />

--- a/src/features/data/index.tsx
+++ b/src/features/data/index.tsx
@@ -19,18 +19,22 @@ function getBase64Song(data: string): Song {
 }
 
 function fetchSong(id: string, source: SongSource): Promise<Song> {
-  if (source === 'midishare' || source === 'builtin') {
+  switch (source) {
+    case 'midishare':
+    case 'builtin':
     const url = getSongUrl(id, source)
     return fetch(url).then(handleSong)
-  } else if (source === 'base64') {
+    case 'base64':
     return Promise.resolve(getBase64Song(id))
-  } else if (source === 'upload') {
+    case 'upload':
     return Promise.resolve(getUploadedSong(id)).then((res) =>
       res === null ? Promise.reject(new Error('Could not find song')) : res,
     )
+    case 'url':
+      return fetch(id).then(handleSong)
+    default:
+      return Promise.reject(new Error(`Could not get song for ${id}, ${source}`))
   }
-
-  return Promise.reject(new Error(`Could not get song for ${id}, ${source}`))
 }
 
 export function useSong(id: string, source: SongSource): SWRResponse<Song, any, any> {

--- a/src/features/persist/constants.ts
+++ b/src/features/persist/constants.ts
@@ -2,3 +2,5 @@
 // keys should not start with a "/" or else breaks url routing
 export const LOCAL_STORAGE_SONG_SUFFIX = 'SONG_DATA'
 export const LOCAL_STORAGE_SONG_LIST_KEY = 'UPLOADS/SONG_LIST'
+export const LOCAL_STORAGE_PLAYLIST_LIST_KEY = 'UPLOADS/PLAYLISTS_LIST'
+export const LOCAL_STORAGE_PLAYLIST_SUFFIX = 'PLAYLIST_DATA'

--- a/src/features/persist/index.ts
+++ b/src/features/persist/index.ts
@@ -4,5 +4,8 @@ export {
   getUploadedSong,
   getPersistedSongSettings,
   saveSong,
+  getPlaylistLibrary,
+  savePlaylist,
+  deletePlaylist,
   setPersistedSongSettings,
 } from './persistence'

--- a/src/features/persist/persistence.ts
+++ b/src/features/persist/persistence.ts
@@ -1,8 +1,9 @@
-import type { Song, SongConfig, SongMetadata } from '@/types'
-import { fileToUint8 } from '@/utils'
+import type { Song, SongConfig, SongMetadata, Playlist } from '@/types'
+import { fileToUint8, fileToString } from '@/utils'
 import { parseMidi } from '../parsers'
-import { LOCAL_STORAGE_SONG_LIST_KEY } from './constants'
+import { LOCAL_STORAGE_SONG_LIST_KEY, LOCAL_STORAGE_PLAYLIST_LIST_KEY } from './constants'
 import Storage from './storage'
+import { Parser } from 'm3u8-parser/dist/m3u8-parser.es.js'
 
 export function hasUploadedSong(id: string): Song | null {
   return Storage.get<Song>(id)
@@ -16,7 +17,17 @@ export function getUploadedLibrary(): SongMetadata[] {
   if (!Storage.has(LOCAL_STORAGE_SONG_LIST_KEY)) {
     Storage.set<SongMetadata[]>(LOCAL_STORAGE_SONG_LIST_KEY, [])
   }
-  return Storage.get<SongMetadata[]>(LOCAL_STORAGE_SONG_LIST_KEY) ?? []
+  const songs = Storage.get<SongMetadata[]>(LOCAL_STORAGE_SONG_LIST_KEY) ?? []
+  const playlists = getPlaylistLibrary()
+  playlists.forEach(playlist => songs.push(...playlist.songs));
+  return songs
+}
+
+export function getPlaylistLibrary(): Playlist[] {
+  if (!Storage.has(LOCAL_STORAGE_PLAYLIST_LIST_KEY)) {
+    Storage.set<Playlist[]>(LOCAL_STORAGE_PLAYLIST_LIST_KEY, [])
+  }
+  return Storage.get<Playlist[]>(LOCAL_STORAGE_PLAYLIST_LIST_KEY) ?? []
 }
 
 /**
@@ -46,6 +57,47 @@ export async function saveSong(file: File, title: string, artist: string): Promi
   Storage.set(LOCAL_STORAGE_SONG_LIST_KEY, library.concat(uploadedSong))
   Storage.set(id, song)
   return uploadedSong
+}
+
+export async function savePlaylist(file:File) {
+  const data = await fileToString(file)
+  let playlist = [];
+  if (data) {
+    playlist = parsePlaylist(data)
+  }
+  const buffer = await fileToUint8(file)
+  const id = await sha1(buffer)
+  const uploadedPlaylist: Playlist = {
+    id: id,
+    name: file.name,
+    songs: playlist.map((song:{uri:string, title:string, duration:number})=>({
+      id: song.uri,
+      title: song.title,
+      artist: '',
+      duration: song.duration,
+      file: '',
+      source: 'url',
+      difficulty: 0,
+    }))
+  };
+  const library = getPlaylistLibrary()
+  if (library.find((s) => s.id === id)) {
+    throw new Error('Cannot upload the same playlist twice')
+  }
+  Storage.set(LOCAL_STORAGE_PLAYLIST_LIST_KEY, library.concat(uploadedPlaylist))
+  return uploadedPlaylist;
+}
+
+export async function deletePlaylist(id: string) {
+  const library = getPlaylistLibrary();
+  Storage.set(LOCAL_STORAGE_PLAYLIST_LIST_KEY, library.filter(p => p.id !== id))
+}
+
+function parsePlaylist(playlist:string){
+  const parser = new Parser();
+  parser.push(playlist);
+  parser.end();
+  return parser.manifest.segments
 }
 
 async function sha1(msgUint8: Uint8Array) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type DifficultyLabel =
   // "-" stands for Unknown
   | '-'
 
-export type SongSource = 'midishare' | 'upload' | 'builtin' | 'generated' | 'base64'
+export type SongSource = 'midishare' | 'upload' | 'builtin' | 'generated' | 'base64' | 'url'
 export type SongMetadata = {
   id: string
   file: string
@@ -75,6 +75,12 @@ export type Song = {
   keySignature: KEY_SIGNATURE
   items: Array<SongNote | SongMeasure>
   backing?: HTMLAudioElement
+}
+
+export type Playlist = {
+  id: string
+  name: string
+  songs: SongMetadata[]
 }
 
 export type Clef = 'bass' | 'treble'


### PR DESCRIPTION
I've added a new feature called playlists. This feature addresses to an extent the issue #62, since it allows easy synchronization of an entire folder with midis to sightread. You can do something like this to generate a playlist with all midis on a folder:
```bash
for file in *.mid
do
   echo "http://localhost:3000/$file">>playlist.m3u8
done
```

And then open a simple server with the folder as:

```bash
python3 -m http.server -p 3000
```

And afterwards if you import the file on the new playlist UI you'll be able to import them automatically to sightread:
![image](https://github.com/user-attachments/assets/8111dda8-356b-479f-a2b4-cfd761af5447)

And since you can remove the playlist and upload it again, you can add new songs easily by replacing the playlist.
Songs themselves are not uploaded to sightread, a new source called 'url' has been added that allows you to play any song directly from an url. So people can also add playlists with midis from around the web for even easier management.

Any questions or feedback to this feature are appreciated.

