### PR TITLE
Mobile UI Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-feather": "2.0.10",
+    "react-full-screen": "1.1.1",
     "tailwind-merge": "2.6.0"
   },
   "scripts": {

--- a/src/app/freeplay/components/TopBar.tsx
+++ b/src/app/freeplay/components/TopBar.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Midi, StartRecord, StopRecord } from '@/icons'
 import { formatInstrumentName } from '@/utils'
 import Link from 'next/link'
 import React, { MouseEvent } from 'react'
-import { Maximize, Minimize } from 'react-feather'
+import { ChevronsUp, Maximize, Minimize } from 'react-feather'
 
 type TopBarProps = {
   isError: boolean
@@ -17,6 +17,7 @@ type TopBarProps = {
   onClickMidi: (e: MouseEvent<any>) => void
   onClickRecord: (e: MouseEvent<any>) => void
   onClickFullScreen: () => void
+  onClickHide: () => void
 }
 
 export default function TopBar({
@@ -29,6 +30,7 @@ export default function TopBar({
   onClickMidi,
   onClickRecord,
   onClickFullScreen,
+  onClickHide,
 }: TopBarProps) {
   const recordTooltip = isRecordingAudio ? 'Stop recording' : 'Start recording audio'
 
@@ -59,6 +61,9 @@ export default function TopBar({
         {isFullScreen ?
           <Minimize size={24} onClick={onClickFullScreen} />:
           <Maximize size={24} onClick={onClickFullScreen} />}
+      </ButtonWithTooltip>
+      <ButtonWithTooltip tooltip="Hide Menu">
+        <ChevronsUp size={24} onClick={onClickHide} />
       </ButtonWithTooltip>
     </div>
   )

--- a/src/app/freeplay/components/TopBar.tsx
+++ b/src/app/freeplay/components/TopBar.tsx
@@ -5,25 +5,30 @@ import { ArrowLeft, Midi, StartRecord, StopRecord } from '@/icons'
 import { formatInstrumentName } from '@/utils'
 import Link from 'next/link'
 import React, { MouseEvent } from 'react'
+import { Maximize, Minimize } from 'react-feather'
 
 type TopBarProps = {
   isError: boolean
   isLoading: boolean
   isRecordingAudio: boolean
+  isFullScreen: boolean
   value: InstrumentName
   onChange: (instrument: InstrumentName) => void
   onClickMidi: (e: MouseEvent<any>) => void
   onClickRecord: (e: MouseEvent<any>) => void
+  onClickFullScreen: () => void
 }
 
 export default function TopBar({
   isError,
   isLoading,
   isRecordingAudio,
+  isFullScreen,
   value,
   onChange,
   onClickMidi,
   onClickRecord,
+  onClickFullScreen,
 }: TopBarProps) {
   const recordTooltip = isRecordingAudio ? 'Stop recording' : 'Start recording audio'
 
@@ -50,6 +55,11 @@ export default function TopBar({
         format={formatInstrumentName as any}
         display={formatInstrumentName as any}
       />
+      <ButtonWithTooltip tooltip="Full Screen">
+        {isFullScreen ?
+          <Minimize size={24} onClick={onClickFullScreen} />:
+          <Maximize size={24} onClick={onClickFullScreen} />}
+      </ButtonWithTooltip>
     </div>
   )
 }

--- a/src/app/freeplay/page.tsx
+++ b/src/app/freeplay/page.tsx
@@ -11,6 +11,8 @@ import RecordingModal from './components/RecordingModal'
 import TopBar from './components/TopBar'
 import FreePlayer from './utils/freePlayer'
 import { FullScreen, useFullScreenHandle } from "react-full-screen";
+import { ButtonWithTooltip } from '@/app/play/components/TopBar.tsx'
+import { ChevronsDown } from 'react-feather'
 
 export default function FreePlay() {
   const [instrumentName, setInstrumentName] = useState<InstrumentName>('acoustic_grand_piano')
@@ -19,6 +21,7 @@ export default function FreePlay() {
   const [isMidiModalOpen, setMidiModal] = useState(false)
   const { isRecording, startRecording, stopRecording } = useRecordMidi(midiState)
   const [recordingPreview, setRecordingPreview] = useState('')
+  const [isHide, setHide] = useState<boolean>(false)
   const fullScreenHandle = useFullScreenHandle()
 
   const handleNoteDown = useCallback(
@@ -54,39 +57,51 @@ export default function FreePlay() {
   return (
     <FullScreen handle={fullScreenHandle}>
       <div className="flex h-screen w-screen flex-col">
-        <TopBar
-          onClickMidi={(e) => {
-            e.stopPropagation()
-            setMidiModal(!isMidiModalOpen)
-          }}
-          onClickRecord={(e) => {
-            e.stopPropagation()
-            if (!isRecording) {
-              startRecording()
-            } else {
-              const midiBytes = stopRecording()
-              if (midiBytes !== null) {
-                const base64MidiData = Buffer.from(midiBytes).toString('base64')
-                setRecordingPreview(base64MidiData)
-              }
-            }
-          }}
-          isRecordingAudio={isRecording}
-          isLoading={synthState.loading}
-          isError={synthState.error}
-          value={instrumentName}
-          onChange={(name) => setInstrumentName(name)}
-          onClickFullScreen={() => fullScreenHandle.active ?
-            fullScreenHandle.exit() :
-            fullScreenHandle.enter()}
-          isFullScreen={fullScreenHandle.active}
-        />
-        <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
-        <RecordingModal
-          show={recordingPreview.length > 0}
-          onClose={() => setRecordingPreview('')}
-          songMeta={{ source: 'base64', id: recordingPreview }}
-        />
+        {!isHide &&
+          <>
+            <TopBar
+              onClickMidi={(e) => {
+                e.stopPropagation()
+                setMidiModal(!isMidiModalOpen)
+              }}
+              onClickRecord={(e) => {
+                e.stopPropagation()
+                if (!isRecording) {
+                  startRecording()
+                } else {
+                  const midiBytes = stopRecording()
+                  if (midiBytes !== null) {
+                    const base64MidiData = Buffer.from(midiBytes).toString('base64')
+                    setRecordingPreview(base64MidiData)
+                  }
+                }
+              }}
+              isRecordingAudio={isRecording}
+              isLoading={synthState.loading}
+              isError={synthState.error}
+              value={instrumentName}
+              onChange={(name) => setInstrumentName(name)}
+              onClickFullScreen={() => fullScreenHandle.active ?
+                fullScreenHandle.exit() :
+                fullScreenHandle.enter()}
+              isFullScreen={fullScreenHandle.active}
+              onClickHide={() => setHide(!isHide)}
+            />
+            <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
+            <RecordingModal
+              show={recordingPreview.length > 0}
+              onClose={() => setRecordingPreview('')}
+              songMeta={{ source: 'base64', id: recordingPreview }}
+            />
+          </>
+        }
+        {isHide &&
+          <div className="flex min-h-[50px] right-[16px] fixed z-10">
+            <ButtonWithTooltip tooltip="Open Menu">
+              <ChevronsDown className={'border rounded-lg'} size={24} onClick={() => setHide(false)} />
+            </ButtonWithTooltip>
+          </div>
+        }
         <div className="relative flex-grow">
           <SongVisualizer
             song={freePlayer.song}

--- a/src/app/freeplay/page.tsx
+++ b/src/app/freeplay/page.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import RecordingModal from './components/RecordingModal'
 import TopBar from './components/TopBar'
 import FreePlayer from './utils/freePlayer'
+import { FullScreen, useFullScreenHandle } from "react-full-screen";
 
 export default function FreePlay() {
   const [instrumentName, setInstrumentName] = useState<InstrumentName>('acoustic_grand_piano')
@@ -18,6 +19,7 @@ export default function FreePlay() {
   const [isMidiModalOpen, setMidiModal] = useState(false)
   const { isRecording, startRecording, stopRecording } = useRecordMidi(midiState)
   const [recordingPreview, setRecordingPreview] = useState('')
+  const fullScreenHandle = useFullScreenHandle()
 
   const handleNoteDown = useCallback(
     (note: number, velocity: number = 80) => {
@@ -50,7 +52,7 @@ export default function FreePlay() {
   }, [handleNoteDown, handleNoteUp])
 
   return (
-    <>
+    <FullScreen handle={fullScreenHandle}>
       <div className="flex h-screen w-screen flex-col">
         <TopBar
           onClickMidi={(e) => {
@@ -74,6 +76,10 @@ export default function FreePlay() {
           isError={synthState.error}
           value={instrumentName}
           onChange={(name) => setInstrumentName(name)}
+          onClickFullScreen={() => fullScreenHandle.active ?
+            fullScreenHandle.exit() :
+            fullScreenHandle.enter()}
+          isFullScreen={fullScreenHandle.active}
         />
         <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
         <RecordingModal
@@ -92,6 +98,6 @@ export default function FreePlay() {
           />
         </div>
       </div>
-    </>
+    </FullScreen>
   )
 }

--- a/src/app/play/components/TopBar.tsx
+++ b/src/app/play/components/TopBar.tsx
@@ -5,26 +5,31 @@ import { isMobile } from '@/utils'
 import clsx from 'clsx'
 import React, { MouseEvent, PropsWithChildren } from 'react'
 import StatusIcon from './StatusIcon'
+import { Maximize, Minimize } from 'react-feather'
 
 type TopBarProps = {
   isLoading: boolean
   isPlaying: boolean
+  isFullScreen: boolean
   title?: string
   onTogglePlaying: () => void
   onClickSettings: (e: MouseEvent<any>) => void
   onClickBack: () => void
   onClickRestart: () => void
   onClickMidi: (e: MouseEvent<any>) => void
+  onClickFullScreen: () => void
   settingsOpen: boolean
 }
 
 export default function TopBar({
   isPlaying,
   isLoading,
+  isFullScreen,
   onTogglePlaying,
   onClickSettings,
   onClickBack,
   onClickRestart,
+  onClickFullScreen,
   settingsOpen,
   title,
   onClickMidi,
@@ -58,6 +63,11 @@ export default function TopBar({
           <Settings size={24} onClick={onClickSettings} />
         </ButtonWithTooltip>
         {!isMobile() && <VolumeSliderButton />}
+        <ButtonWithTooltip tooltip="Full Screen">
+          {isFullScreen ?
+            <Minimize size={24} onClick={onClickFullScreen} />:
+            <Maximize size={24} onClick={onClickFullScreen} />}
+        </ButtonWithTooltip>
       </div>
     </div>
   )

--- a/src/app/play/components/TopBar.tsx
+++ b/src/app/play/components/TopBar.tsx
@@ -3,9 +3,10 @@ import { VolumeSliderButton } from '@/features/controls'
 import { ArrowLeft, Midi, Settings, SkipBack } from '@/icons'
 import { isMobile } from '@/utils'
 import clsx from 'clsx'
-import React, { MouseEvent, PropsWithChildren } from 'react'
+import React, { MouseEvent, PropsWithChildren, useEffect, useState } from 'react'
 import StatusIcon from './StatusIcon'
-import { ChevronsUp, Maximize, Minimize } from 'react-feather'
+import { ChevronsUp, Maximize, Menu, Minimize } from 'react-feather'
+import useWindowWidth from '@/hooks/useWindowWidth';
 
 type TopBarProps = {
   isLoading: boolean
@@ -36,6 +37,12 @@ export default function TopBar({
   title,
   onClickMidi,
 }: TopBarProps) {
+  const [showMore, setShowMore] = useState<boolean>(false)
+  const windowWidth = useWindowWidth();
+  useEffect(() => {
+    setShowMore(false);
+  }, [windowWidth]);
+
   return (
     <div className="align-center relative z-10 flex h-[50px] min-h-[50px] w-screen justify-end gap-8 bg-[#292929] px-1">
       <ButtonWithTooltip
@@ -57,8 +64,13 @@ export default function TopBar({
         </ButtonWithTooltip>
         <StatusIcon isPlaying={isPlaying} isLoading={isLoading} onTogglePlaying={onTogglePlaying} />
       </div>
-      <div className="hidden h-full items-center text-white sm:ml-auto sm:flex">{title}</div>
-      <div className="mr-[20px] flex h-full items-center gap-8">
+      <div className="hidden w-1/4 lg:w-1/5 h-full items-center text-white sm:ml-auto sm:flex">
+        <div className="overflow-hidden whitespace-nowrap overflow-ellipsis">{title}</div>
+      </div>
+      <ButtonWithTooltip tooltip={"menu"} className="mr-3 min-h-[50px] xs:hidden absolute" isActive={showMore}>
+        <Menu size={24} onClick={() => setShowMore(!showMore)} />
+      </ButtonWithTooltip>
+      <div className={(showMore ? "flex flex-col mt-[50px] p-2 mr-1 h-fit bg-[#292929]": "hidden mr-[20px] h-full" ) + " xs:flex items-center gap-8"}>
         <ButtonWithTooltip tooltip="Choose a MIDI device">
           <Midi size={24} onClick={onClickMidi} />
         </ButtonWithTooltip>

--- a/src/app/play/components/TopBar.tsx
+++ b/src/app/play/components/TopBar.tsx
@@ -5,7 +5,7 @@ import { isMobile } from '@/utils'
 import clsx from 'clsx'
 import React, { MouseEvent, PropsWithChildren } from 'react'
 import StatusIcon from './StatusIcon'
-import { Maximize, Minimize } from 'react-feather'
+import { ChevronsUp, Maximize, Minimize } from 'react-feather'
 
 type TopBarProps = {
   isLoading: boolean
@@ -18,6 +18,7 @@ type TopBarProps = {
   onClickRestart: () => void
   onClickMidi: (e: MouseEvent<any>) => void
   onClickFullScreen: () => void
+  onClickHide: () => void
   settingsOpen: boolean
 }
 
@@ -30,12 +31,13 @@ export default function TopBar({
   onClickBack,
   onClickRestart,
   onClickFullScreen,
+  onClickHide,
   settingsOpen,
   title,
   onClickMidi,
 }: TopBarProps) {
   return (
-    <div className="align-center relative z-10 flex h-[50px] min-h-[50px] w-screen justify-center gap-8 bg-[#292929] px-1">
+    <div className="align-center relative z-10 flex h-[50px] min-h-[50px] w-screen justify-end gap-8 bg-[#292929] px-1">
       <ButtonWithTooltip
         tooltip="Back"
         className="!absolute left-3 top-1/2 -translate-y-1/2"
@@ -46,7 +48,8 @@ export default function TopBar({
       <div
         className={clsx(
           'flex h-full items-center gap-8',
-          'sm:absolute sm:left-1/2 sm:-translate-x-3/4',
+          'left-16 absolute',
+          'lg:absolute lg:left-1/2 lg:-translate-x-3/4',
         )}
       >
         <ButtonWithTooltip tooltip="Restart">
@@ -67,6 +70,9 @@ export default function TopBar({
           {isFullScreen ?
             <Minimize size={24} onClick={onClickFullScreen} />:
             <Maximize size={24} onClick={onClickFullScreen} />}
+        </ButtonWithTooltip>
+        <ButtonWithTooltip tooltip="Hide Menu">
+          <ChevronsUp size={24} onClick={onClickHide} />
         </ButtonWithTooltip>
       </div>
     </div>

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -189,11 +189,20 @@ function PlaySongLegacy() {
           </>
         )}
         {!isRecording && isHide &&
-          <div className="flex min-h-[50px] right-[24px] fixed">
-            <ButtonWithTooltip tooltip="Open Menu" >
-              <ChevronsDown className={"border rounded-lg"} size={24} onClick={() => setHide(false)} />
-            </ButtonWithTooltip>
-          </div>
+          <>
+            <div className="relative min-w-full w-screen">
+              <SongScrubBar
+                minimized={true}
+                rangeSelection={selectedRange}
+                height={2}
+              />
+            </div>
+            <div className="flex min-h-[50px] right-[24px] fixed">
+              <ButtonWithTooltip tooltip="Open Menu" >
+                <ChevronsDown className={"border rounded-lg"} size={24} onClick={() => setHide(false)} />
+              </ButtonWithTooltip>
+            </div>
+          </>
         }
         <div
           className={clsx(

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -22,6 +22,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import React, { Suspense, useEffect, useMemo, useState } from 'react'
 import { SettingsPanel, TopBar } from './components'
 import { MidiModal } from './components/MidiModal'
+import { FullScreen, useFullScreenHandle } from "react-full-screen";
 
 // This function exists as hack to stop the CSR deopt warning.
 // To do this the "next app router" way would require boxing up the bits
@@ -36,6 +37,7 @@ function PlaySongLegacy() {
 
   const [settingsOpen, setSettingsPanel] = useState(false)
   const [isMidiModalOpen, setMidiModal] = useState(false)
+  const fullScreenHandle = useFullScreenHandle()
   const playerState = usePlayerState()
   const synth = useSingleton(() => getSynthStub('acoustic_grand_piano'))
   let { data: song } = useSong(id, source)
@@ -128,7 +130,7 @@ function PlaySongLegacy() {
   }
 
   return (
-    <>
+    <FullScreen handle={fullScreenHandle}>
       <div
         className={clsx(
           // Enable fixed to remove all scrolling.
@@ -156,6 +158,10 @@ function PlaySongLegacy() {
                 e.stopPropagation()
                 setSettingsPanel(!settingsOpen)
               }}
+              onClickFullScreen={() => fullScreenHandle.active ?
+                fullScreenHandle.exit() :
+                fullScreenHandle.enter()}
+              isFullScreen={fullScreenHandle.active}
               settingsOpen={settingsOpen}
             />
             <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
@@ -196,7 +202,7 @@ function PlaySongLegacy() {
           />
         </div>
       </div>
-    </>
+    </FullScreen>
   )
 }
 

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -23,6 +23,8 @@ import React, { Suspense, useEffect, useMemo, useState } from 'react'
 import { SettingsPanel, TopBar } from './components'
 import { MidiModal } from './components/MidiModal'
 import { FullScreen, useFullScreenHandle } from "react-full-screen";
+import { ButtonWithTooltip } from '@/app/play/components/TopBar.tsx'
+import { ChevronsDown } from 'react-feather'
 
 // This function exists as hack to stop the CSR deopt warning.
 // To do this the "next app router" way would require boxing up the bits
@@ -37,6 +39,7 @@ function PlaySongLegacy() {
 
   const [settingsOpen, setSettingsPanel] = useState(false)
   const [isMidiModalOpen, setMidiModal] = useState(false)
+  const [isHide, setHide] = useState<boolean>(false)
   const fullScreenHandle = useFullScreenHandle()
   const playerState = usePlayerState()
   const synth = useSingleton(() => getSynthStub('acoustic_grand_piano'))
@@ -138,7 +141,7 @@ function PlaySongLegacy() {
           'max-w-screen flex h-screen max-h-screen flex-col',
         )}
       >
-        {!isRecording && (
+        {!isRecording && !isHide && (
           <>
             <TopBar
               title={songMeta?.title}
@@ -162,6 +165,7 @@ function PlaySongLegacy() {
                 fullScreenHandle.exit() :
                 fullScreenHandle.enter()}
               isFullScreen={fullScreenHandle.active}
+              onClickHide={() => setHide(!isHide)}
               settingsOpen={settingsOpen}
             />
             <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
@@ -184,6 +188,13 @@ function PlaySongLegacy() {
             </div>
           </>
         )}
+        {!isRecording && isHide &&
+          <div className="flex min-h-[50px] right-[24px] fixed">
+            <ButtonWithTooltip tooltip="Open Menu" >
+              <ChevronsDown className={"border rounded-lg"} size={24} onClick={() => setHide(false)} />
+            </ButtonWithTooltip>
+          </div>
+        }
         <div
           className={clsx(
             'fixed -z-10 h-[100vh] w-screen',

--- a/src/app/songs/components/Table/Table.tsx
+++ b/src/app/songs/components/Table/Table.tsx
@@ -49,9 +49,9 @@ export default function Table<T extends Row>({
           rowHeight={rowHeight}
         />
       </div>
-      <div className="relative flex flex-grow">
+      <div className="relative flex flex-grow min-h-64">
         <div
-          className="absolute grid h-full w-full overflow-y-scroll rounded-md bg-white shadow-md"
+          className="absolute grid h-full w-full overflow-y-scroll rounded-md bg-white shadow-md content-start"
           style={{ gridTemplateColumns }}
         >
           {sorted.length === 0 && <h2 className="p-5 text-2xl">No results</h2>}

--- a/src/features/SongVisualization/falling-notes.ts
+++ b/src/features/SongVisualization/falling-notes.ts
@@ -76,7 +76,10 @@ function deriveState(state: GivenState): State {
   const notes: SongNote[] = items
     ? (items.filter((i) => i.type === 'note') as SongNote[])
     : ([{ midiNote: 21 }, { midiNote: 108 }] as SongNote[])
-  const { startNote, endNote } = getSongRange({ notes })
+
+  const minNotes = Math.floor(Math.max(36, 50 * ( state.windowWidth / state.height)))
+
+  const { startNote, endNote } = getSongRange({ notes }, minNotes)
 
   const pianoMeasurements = getPianoRollMeasurements(state.windowWidth, { startNote, endNote })
   const { whiteHeight } = pianoMeasurements

--- a/src/features/SongVisualization/utils.ts
+++ b/src/features/SongVisualization/utils.ts
@@ -6,7 +6,7 @@ import { isBlack } from '../theory'
 import { parserInferHands } from '../parsers'
 import { GivenState } from './canvasRenderer'
 
-export function getSongRange(song: { notes: SongNote[] } | undefined) {
+export function getSongRange(song: { notes: SongNote[] } | undefined, minNotes: number) {
   const notes = song?.notes ?? []
   let startNote = notes[0]?.midiNote ?? 21
   let endNote = notes[0]?.midiNote ?? 108
@@ -18,8 +18,8 @@ export function getSongRange(song: { notes: SongNote[] } | undefined) {
 
   // Ensure we show at least a min of 36 notes just so it doesn't look ridiculous
   const diff = endNote - startNote
-  if (diff < 36) {
-    const fix = Math.floor((36 - diff) / 2)
+  if (diff < minNotes) {
+    const fix = Math.floor((minNotes - diff) / 2)
     startNote -= fix
     endNote += fix
   }

--- a/src/features/controls/SongScrubBar.tsx
+++ b/src/features/controls/SongScrubBar.tsx
@@ -14,12 +14,14 @@ export default function SongScrubBar({
   onSeek = () => {},
   onClick = () => {},
   rangeSelection,
+  minimized = false
 }: {
   rangeSelection?: undefined | { start: number; end: number }
   setRange?: any
   onSeek?: any
   height: number
-  onClick?: any
+  onClick?: any,
+  minimized?: boolean
 }) {
   const [pointerOver, setPointerOver] = useState(false)
   const divRef = useRef<HTMLDivElement>(null)
@@ -153,26 +155,29 @@ export default function SongScrubBar({
         timeSpanRef.current.innerText = formatTime(player.getRealTimeDuration(0, songTime))
       }}
     >
-      <div
-        className={clsx(
-          pointerOver ? 'flex' : 'hidden',
-          'absolute z-30 min-w-max items-center justify-between gap-8',
-          '-top-1 rounded-lg bg-black/90 px-4 py-2',
-          '-translate-y-full',
-        )}
-        ref={toolTipRef}
-      >
-        <span className="text-gray-300">
-          Time: <span className="text-sm text-purple-hover" ref={timeSpanRef} />
-        </span>
-        <span className="text-gray-300">
-          Measure: <span className="text-sm text-purple-hover" ref={measureSpanRef} />
-        </span>
-      </div>
-      <span ref={currentTimeRef} className="min-w-[80px] self-center px-4 py-2 text-black" />
+      {!minimized &&
+      <>
+        <div
+          className={clsx(
+            pointerOver ? 'flex' : 'hidden',
+            'absolute z-30 min-w-max items-center justify-between gap-8',
+            '-top-1 rounded-lg bg-black/90 px-4 py-2',
+            '-translate-y-full',
+          )}
+          ref={toolTipRef}
+        >
+          <span className="text-gray-300">
+            Time: <span className="text-sm text-purple-hover" ref={timeSpanRef} />
+          </span>
+          <span className="text-gray-300">
+            Measure: <span className="text-sm text-purple-hover" ref={measureSpanRef} />
+          </span>
+        </div>
+        <span ref={currentTimeRef} className="min-w-[80px] self-center px-4 py-2 text-black" />
+      </>}
       <div
         ref={progressBarRef}
-        className="relative h-4 flex-grow self-center overflow-hidden rounded-full"
+        className={"relative flex-grow self-center overflow-hidden rounded-full " + (minimized? "h-1" : "h-4")}
         onPointerOver={() => setPointerOver(true)}
         onPointerOut={() => setPointerOver(false)}
       >
@@ -184,26 +189,36 @@ export default function SongScrubBar({
           style={{ left: -width }}
         />
       </div>
-      <span className="min-w-[80px] self-center px-4 py-2 text-black">
-        {song ? formatTime(player.getRealTimeDuration(0, song.duration)) : '00:00'}
-      </span>
-      {rangeSelection && (
+      {!minimized &&
+        <span className="min-w-[80px] self-center px-4 py-2 text-black">
+          {song ? formatTime(player.getRealTimeDuration(0, song.duration)) : '00:00'}
+        </span>
+      }
+      {rangeSelection && (minimized? (
         <div ref={rangeRef} className="pointer-events-none absolute flex h-full items-center">
-          <div className="absolute h-4 w-[calc(100%-10px)] bg-purple-dark/40" />
-          <div
-            className="pointer-events-auto absolute left-0 h-6 w-6 -translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90"
-            onPointerEnter={() => setPointerOver(true)}
-            onPointerLeave={() => setPointerOver(false)}
-            onPointerDown={() => (isDraggingL.current = true)}
-          />
-          <div
-            className="pointer-events-auto absolute right-0 h-6 w-6 translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90"
-            onPointerDown={() => (isDraggingR.current = true)}
-            onPointerEnter={() => setPointerOver(true)}
-            onPointerLeave={() => setPointerOver(false)}
-          />
+          <div className="absolute h-1 w-[calc(100%-2px)] bg-purple-dark/40" />
+          <div className="absolute left-0 h-2 w-2 -translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90" />
+          <div className="absolute right-0 h-2 w-2 translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90" />
         </div>
-      )}
+        ):
+        (
+          <div ref={rangeRef} className="pointer-events-none absolute flex h-full items-center">
+            <div className="absolute h-4 w-[calc(100%-10px)] bg-purple-dark/40" />
+            <div
+              className="pointer-events-auto absolute left-0 h-6 w-6 -translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90"
+              onPointerEnter={() => setPointerOver(true)}
+              onPointerLeave={() => setPointerOver(false)}
+              onPointerDown={() => (isDraggingL.current = true)}
+            />
+            <div
+              className="pointer-events-auto absolute right-0 h-6 w-6 translate-x-1/2 cursor-pointer rounded-full bg-purple-dark/90 transition hover:bg-purple-hover/90"
+              onPointerDown={() => (isDraggingR.current = true)}
+              onPointerEnter={() => setPointerOver(true)}
+              onPointerLeave={() => setPointerOver(false)}
+            />
+          </div>
+        ))
+      }
     </div>
   )
 }

--- a/src/features/controls/SongScrubBar.tsx
+++ b/src/features/controls/SongScrubBar.tsx
@@ -96,7 +96,7 @@ export default function SongScrubBar({
   })
 
   useEventListener<PointerEvent>(
-    'click',
+    'pointerup',
     (e) => {
       const target = e.target as HTMLElement
       const completedAction = isDraggingL.current || isDraggingR.current || isScrubbing.current
@@ -129,7 +129,7 @@ export default function SongScrubBar({
 
   return (
     <div
-      className="relative flex w-full select-none border-b border-b-black bg-gray-300"
+      className="relative flex w-full select-none border-b border-b-black bg-gray-300 touch-none"
       onClick={onClick}
       style={{ height }}
       ref={wrapperRef}

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -54,6 +54,7 @@ export function formatTime(seconds: number) {
 }
 
 export const breakpoints = {
+  xs: 440,
   sm: 650,
   md: 800,
   lg: 1100,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     screens: {
+      xs: '440px',
       sm: '650px',
       md: '800px',
       lg: '1100px',


### PR DESCRIPTION
This PR enhances the user experience on small devices (e.g., smartphones) and touchscreens. The updates ensure better screen utilization, and improved responsiveness across various device sizes.
Changes Made:
- Zoom out for wide screens: Optimized scaling for wider displays. You were not able to see the falling notes.
- Added fullscreen toggle button: Allows users to easily enter/exit fullscreen to have more space to visualize notes.
- Added button to hide top menu bar: Gives users the option to hide the top menu for the same purpose.
    - Thin progress bar when the menu is hidden: Displays a minimal progress bar for visual feedback without obstructing the view.
- Automatically collapse menu for small screens: Prevent icons to paint on top of each other in small screens.

- Other fixes, like ensure the song list is visible in small screens or make the scrub bar draggable on touchscreens.

Overall, it goes from this:
![Before](https://github.com/user-attachments/assets/949b3c94-c272-47dd-b831-f731ef10e2cf)
To this:
![After](https://github.com/user-attachments/assets/4cfd620d-da57-43a3-bb93-1f8be4e544dc)