### PR TITLE
Preview tracks in song config

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -159,7 +159,7 @@ function PlaySongLegacy() {
               settingsOpen={settingsOpen}
             />
             <MidiModal isOpen={isMidiModalOpen} onClose={() => setMidiModal(false)} />
-            <div className={clsx(!settingsOpen && 'hidden')}>
+            {settingsOpen && (
               <SettingsPanel
                 onClose={() => setSettingsPanel(false)}
                 onChange={setSongConfig}
@@ -168,7 +168,7 @@ function PlaySongLegacy() {
                 onLoopToggled={handleLoopingToggle}
                 isLooping={isLooping}
               />
-            </div>
+            )}
             <div className="relative min-w-full">
               <SongScrubBar
                 rangeSelection={selectedRange}

--- a/src/features/controls/AdjustInstruments.tsx
+++ b/src/features/controls/AdjustInstruments.tsx
@@ -131,9 +131,10 @@ function InstrumentCard({ track, trackId, song, setTrack, noteCount, onPlayTrack
   const player = usePlayer()
   const [isPlaying, setPlaying] = useState<boolean>(false)
 
-  const handlePlayTrack = (isPlaying: boolean) => {
-    setPlaying(isPlaying)
-    onPlayTrack(trackId, isPlaying)
+  const handlePlayTrack = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setPlaying(!isPlaying)
+    onPlayTrack(trackId, !isPlaying)
   }
 
   const handleRestoreTrack = () => {
@@ -177,6 +178,8 @@ function InstrumentCard({ track, trackId, song, setTrack, noteCount, onPlayTrack
         </span>
         <span className="bg-purple-light mx-1 my-2 h-6 w-[2px]"></span>
         <span>{noteCount} Notes</span>
+        <TogglePlayTrack on={isPlaying} onClick={handlePlayTrack} />
+        <RestoreTrack onClick={handleRestoreTrack} />
       </div>
       <InstrumentSelect
         value={track.instrument}
@@ -187,11 +190,8 @@ function InstrumentCard({ track, trackId, song, setTrack, noteCount, onPlayTrack
       <TrackSettingsSection
         hand={track.hand}
         sound={track.sound}
-        playTrack={isPlaying}
         onSelectHand={handleSelectHand}
         onToggleSound={handleSound}
-        onTogglePlayTrack={handlePlayTrack}
-        onRestoreTrack={handleRestoreTrack}
       />
     </span>
   )
@@ -224,26 +224,13 @@ function InstrumentSelect({
 type TrackSettingProps = {
   hand: 'left' | 'right' | 'none'
   sound: boolean
-  playTrack: boolean
   onSelectHand: (hand: 'left' | 'right' | 'none') => void
   onToggleSound: (sound: boolean) => void
-  onTogglePlayTrack: (playTrack: boolean) => void
-  onRestoreTrack: () => void
 }
-function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSound, onTogglePlayTrack, onRestoreTrack }: TrackSettingProps) {
+function TrackSettingsSection({ hand, sound, onSelectHand, onToggleSound }: TrackSettingProps) {
   const handleSound = (e: React.MouseEvent) => {
     e.stopPropagation()
     onToggleSound(!sound)
-  }
-
-  const handlePlayTrack = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    onTogglePlayTrack(!playTrack)
-  }
-
-  const handleRestoreTrack = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    onRestoreTrack()
   }
 
   return (
@@ -261,8 +248,6 @@ function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSo
         }}
       />
       <ToggleSound on={sound} onClick={handleSound} />
-      <TogglePlayTrack on={playTrack} onClick={handlePlayTrack} />
-      <RestoreTrack onClick={handleRestoreTrack} />
     </div>
   )
 }
@@ -323,17 +308,15 @@ function ToggleSound({ on, onClick }: ToggleIconProps) {
 }
 
 function TogglePlayTrack({ on, onClick }: ToggleIconProps) {
-  const labelText = on ? 'Stop track' : 'Play track'
 
   return (
-    <button className="flex flex-col items-center">
+    <button className="ml-2 mr-6 flex flex-col items-center">
       <Play
-        height={32}
-        width={32}
+        height={24}
+        width={24}
         className={clsx(on ? 'text-purple-primary fill-purple-primary' : 'hover:fill-purple-primary')}
         onClick={onClick}
       />
-      <span style={labelStyle}>{labelText}</span>
     </button>
   )
 }
@@ -341,14 +324,13 @@ function TogglePlayTrack({ on, onClick }: ToggleIconProps) {
 function RestoreTrack({ onClick }: {onClick: (e: React.MouseEvent) => void}) {
 
   return (
-    <button className="flex flex-col items-center">
+    <button className="ml-auto flex flex-col items-center">
       <RefreshCcw
-        height={32}
-        width={32}
+        height={24}
+        width={24}
         className={clsx('transition-transform duration-300 ease-in-out hover:-rotate-45')}
         onClick={onClick}
       />
-      <span style={labelStyle}>Restore default</span>
     </button>
   )
 }

--- a/src/features/controls/AdjustInstruments.tsx
+++ b/src/features/controls/AdjustInstruments.tsx
@@ -8,7 +8,7 @@ import { Song, SongConfig, TrackSetting } from '@/types'
 import { formatInstrumentName } from '@/utils'
 import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
-import { createStore } from 'jotai'
+import { getDefaultStore } from 'jotai'
 import { RefreshCcw } from 'react-feather'
 import { getDefaultSongSettings } from '@/features/SongVisualization/utils.ts'
 
@@ -18,7 +18,7 @@ type InstrumentSettingsProps = {
   setTracks: (tracks: { [id: number]: TrackSetting }) => void
 }
 
-const miniPlayer = new Player(createStore());
+const miniPlayer = new Player(getDefaultStore());
 
 export default function AdjustInstruments({ setTracks, config, song }: InstrumentSettingsProps) {
   const tracks = config.tracks

--- a/src/features/controls/AdjustInstruments.tsx
+++ b/src/features/controls/AdjustInstruments.tsx
@@ -9,6 +9,8 @@ import { formatInstrumentName } from '@/utils'
 import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
 import { createStore } from 'jotai'
+import { RefreshCcw } from 'react-feather'
+import { getDefaultSongSettings } from '@/features/SongVisualization/utils.ts'
 
 type InstrumentSettingsProps = {
   config: SongConfig
@@ -87,6 +89,7 @@ export default function AdjustInstruments({ setTracks, config, song }: Instrumen
           <InstrumentCard
             track={settings}
             trackId={+track}
+            song={song}
             key={track}
             setTrack={handleSetTrack}
             noteCount={song?.notes.filter((n) => n.track === +track).length ?? 0}
@@ -100,6 +103,7 @@ export default function AdjustInstruments({ setTracks, config, song }: Instrumen
 
 type CardProps = {
   track: TrackSetting
+  song?: Song
   key: string
   trackId: number
   setTrack: (trackId: number, track: TrackSetting) => void
@@ -108,7 +112,7 @@ type CardProps = {
 }
 type SynthState = { error: boolean; loading: boolean }
 
-function InstrumentCard({ track, trackId, setTrack, noteCount, onPlayTrack }: CardProps) {
+function InstrumentCard({ track, trackId, song, setTrack, noteCount, onPlayTrack }: CardProps) {
   const [synthState, setSynthState] = useState<SynthState>({ error: false, loading: false })
   const player = usePlayer()
   const [isPlaying, setPlaying] = useState<boolean>(false)
@@ -116,6 +120,15 @@ function InstrumentCard({ track, trackId, setTrack, noteCount, onPlayTrack }: Ca
   const handlePlayTrack = (isPlaying: boolean) => {
     setPlaying(isPlaying)
     onPlayTrack(trackId, isPlaying)
+  }
+
+  const handleRestoreTrack = () => {
+    if (song) {
+      const defaultTrack = getDefaultSongSettings(song).tracks[trackId]
+      if (defaultTrack) {
+        setTrack(trackId, defaultTrack)
+      }
+    }
   }
 
   const handleSelectInstrument = (instrument: InstrumentName) => {
@@ -164,6 +177,7 @@ function InstrumentCard({ track, trackId, setTrack, noteCount, onPlayTrack }: Ca
         onSelectHand={handleSelectHand}
         onToggleSound={handleSound}
         onTogglePlayTrack={handlePlayTrack}
+        onRestoreTrack={handleRestoreTrack}
       />
     </span>
   )
@@ -200,8 +214,9 @@ type TrackSettingProps = {
   onSelectHand: (hand: 'left' | 'right' | 'none') => void
   onToggleSound: (sound: boolean) => void
   onTogglePlayTrack: (playTrack: boolean) => void
+  onRestoreTrack: () => void
 }
-function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSound, onTogglePlayTrack }: TrackSettingProps) {
+function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSound, onTogglePlayTrack, onRestoreTrack }: TrackSettingProps) {
   const handleSound = (e: React.MouseEvent) => {
     e.stopPropagation()
     onToggleSound(!sound)
@@ -210,6 +225,11 @@ function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSo
   const handlePlayTrack = (e: React.MouseEvent) => {
     e.stopPropagation()
     onTogglePlayTrack(!playTrack)
+  }
+
+  const handleRestoreTrack = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onRestoreTrack()
   }
 
   return (
@@ -228,6 +248,7 @@ function TrackSettingsSection({ hand, sound, playTrack, onSelectHand, onToggleSo
       />
       <ToggleSound on={sound} onClick={handleSound} />
       <TogglePlayTrack on={playTrack} onClick={handlePlayTrack} />
+      <RestoreTrack onClick={handleRestoreTrack} />
     </div>
   )
 }
@@ -299,6 +320,21 @@ function TogglePlayTrack({ on, onClick }: ToggleIconProps) {
         onClick={onClick}
       />
       <span style={labelStyle}>{labelText}</span>
+    </button>
+  )
+}
+
+function RestoreTrack({ onClick }: {onClick: (e: React.MouseEvent) => void}) {
+
+  return (
+    <button className="flex flex-col items-center">
+      <RefreshCcw
+        height={32}
+        width={32}
+        className={clsx('transition-transform duration-300 ease-in-out hover:-rotate-45')}
+        onClick={onClick}
+      />
+      <span style={labelStyle}>Restore default</span>
     </button>
   )
 }

--- a/src/features/controls/AdjustInstruments.tsx
+++ b/src/features/controls/AdjustInstruments.tsx
@@ -82,6 +82,15 @@ export default function AdjustInstruments({ setTracks, config, song }: Instrumen
     }
   }
 
+  const handleRestoreAll = () => {
+    if (song) {
+      const defaultSettings = getDefaultSongSettings(song)
+      if (defaultSettings) {
+        setTracks(defaultSettings.tracks);
+      }
+    }
+  }
+
   return (
     <>
       {Object.entries(tracks).map(([track, settings]) => {
@@ -97,6 +106,11 @@ export default function AdjustInstruments({ setTracks, config, song }: Instrumen
           />
         )
       })}
+      <div className="w-full flex justify-center" >
+        <span className="m-4 p-4 rounded-md border border-black bg-white">
+          <RestoreAll onClick={handleRestoreAll} />
+        </span>
+      </div>
     </>
   )
 }
@@ -335,6 +349,20 @@ function RestoreTrack({ onClick }: {onClick: (e: React.MouseEvent) => void}) {
         onClick={onClick}
       />
       <span style={labelStyle}>Restore default</span>
+    </button>
+  )
+}
+
+function RestoreAll({ onClick }: { onClick: (e: React.MouseEvent) => void }) {
+  return (
+    <button className="flex flex-col items-center justify-center">
+      <RefreshCcw
+        height={32}
+        width={32}
+        className={clsx('transition-transform duration-300 ease-in-out hover:-rotate-45')}
+        onClick={onClick}
+      />
+      <span style={labelStyle}>Reset all</span>
     </button>
   )
 }


### PR DESCRIPTION
This PR enables playing individual tracks in the song config menu to easily identify which tracks to enable or disable.

This also adds buttons to restore a track to its default settings (hands, instrument and enable/disable).