### PR TITLE
Fixes

### DIFF
--- a/src/app/songs/components/UploadSong/UploadSongForm.tsx
+++ b/src/app/songs/components/UploadSong/UploadSongForm.tsx
@@ -131,7 +131,7 @@ export default function UploadForm({ onClose }: { onClose: () => void }) {
           id="file"
           name="file"
           type="file"
-          accept=".mid, .xml"
+          accept=".mid,audio/midi,audio/x-midi,.xml,application/xml,text/xml"
           className="hidden"
         />
         <div

--- a/src/features/player/player.ts
+++ b/src/features/player/player.ts
@@ -204,11 +204,14 @@ export class Player {
       const instrument =
         songConfig.tracks[+trackId]?.instrument ?? config.program ?? config.instrument ?? 0
       synths[+trackId] = getSynth(instrument)
-      const vol = songConfig.tracks[+trackId]?.sound ? 1 : 0
-      this.setTrackVolume(+trackId, vol)
     })
     await Promise.all(synths).then((s) => {
       this.synths = s
+      // setTrackVolume must be called after synths have been set
+      Object.entries(song.tracks).forEach(([trackId]) => {
+        const vol = songConfig.tracks[+trackId]?.sound ? 1 : 0
+        this.setTrackVolume(+trackId, vol)
+      });
       this.store.set(this.state, 'Paused')
     })
     // this.skipMissedNotes = songConfig.skipMissedNotes

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+    const response = NextResponse.next();
+
+    if (request.nextUrl.pathname.startsWith("/soundfonts")) {
+        response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    }
+
+    return response;
+}
+


### PR DESCRIPTION
This PR includes several fixes and improvements:

- Changed the 'accept' attribute in the file upload form for better browser support. Some browsers rely on file types instead of file extensions.
- Set persisted track volumes after synths have loaded; otherwise, the enable/disable settings in the track configuration are not properly applied.
- Created middleware to use the Cache-Control header, instructing the browser to cache soundfont resources. This prevents them from being loaded every time.