### PR TITLE
hotfix: useSWR revalidations of the page using broken compare

### DIFF
--- a/src/features/data/index.tsx
+++ b/src/features/data/index.tsx
@@ -1,6 +1,7 @@
 import { parseMidi } from '@/features/parsers'
 import { Song, SongSource } from '@/types'
-import useSWR, { type SWRResponse } from 'swr'
+import type { SWRResponse } from 'swr'
+import useSWRImmutable from 'swr/immutable'
 import { getSongHandle } from '../persist/persistence'
 
 async function handleSong(response: Response): Promise<Song> {
@@ -33,5 +34,5 @@ async function fetchSong(id: string, source: SongSource): Promise<Song> {
 }
 
 export function useSong(id: string, source: SongSource): SWRResponse<Song, any, any> {
-  return useSWR([id, source], ([id, source]) => fetchSong(id, source))
+  return useSWRImmutable([id, source], ([id, source]) => fetchSong(id, source))
 }


### PR DESCRIPTION
When adding metronome we also updated [Song] to have three new functions attached to it. The builtin compare for useSWR could no longer determine that the song hadn't changed, because the object identity of the new functions were different.

While we should think about fixing that, a better fix for this instance would be to use useSWRImmutable instead, since we can assume songdata will never change during the lifetime of a session.