### PR TITLE
Auto focus search bar on /songs page

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -7,9 +7,10 @@ type TextInputProps = {
   className?: string
   error?: boolean
   placeholder?: string
+  autoFocus?: boolean
 }
 export function TextInput(props: TextInputProps) {
-  const { onChange, name, className, error, type, placeholder } = props
+  const { onChange, name, className, error, type, placeholder, autoFocus } = props
   return (
     <input
       type={type}
@@ -21,6 +22,7 @@ export function TextInput(props: TextInputProps) {
         error && 'outline outline-red-600',
       )}
       placeholder={placeholder}
+      autoFocus={autoFocus}
     />
   )
 }

--- a/src/pages/songs/components/Table/SearchBox.tsx
+++ b/src/pages/songs/components/Table/SearchBox.tsx
@@ -1,8 +1,13 @@
 import { TextInput } from '@/components/TextInput'
 import { Search } from '@/icons'
 
-export type SearchBoxProps = { onSearch: (val: string) => void; placeholder: string }
-export function SearchBox({ onSearch, placeholder }: SearchBoxProps) {
+export type SearchBoxProps = { 
+  onSearch: (val: string) => void;
+  placeholder: string
+  autoFocus?: boolean
+}
+
+export function SearchBox({ onSearch, placeholder, autoFocus }: SearchBoxProps) {
   return (
     <div className="relative h-[40px] w-80">
       <TextInput
@@ -10,6 +15,7 @@ export function SearchBox({ onSearch, placeholder }: SearchBoxProps) {
         onChange={(e: any) => onSearch(e.target.value)}
         className="absolute h-full w-full rounded-md bg-gray-100 pl-10 placeholder-gray-700 placeholder:text-base"
         placeholder={placeholder}
+        autoFocus={autoFocus}
       />
       <Search size={20} className="absolute top-1/2 left-3 -translate-y-1/2" />
     </div>

--- a/src/pages/songs/page.tsx
+++ b/src/pages/songs/page.tsx
@@ -57,7 +57,7 @@ export default function SelectSongPage() {
           <h3 className="text-base"> Select a song, choose your settings, and begin learning</h3>
           <Sizer height={24} />
           <div className="flex gap-4">
-            <SearchBox placeholder={'Search Songs by Title or Artist'} onSearch={setSearch} />
+            <SearchBox placeholder={'Search Songs by Title or Artist'} onSearch={setSearch} autoFocus={true}/>
             <button
               className={clsx(
                 'hidden flex-nowrap whitespace-nowrap sm:flex',


### PR DESCRIPTION
Hi,

This PR intends to fix a small UI nit which is always having to manually click 
search bar whenever visiting `/songs` page.

Now, once `/songs` page loads user can directly start typing to search a song.
