### PR TITLE
fix: filter out MIDI polyphonic aftertouch messages

### DIFF
--- a/src/features/midi/index.tsx
+++ b/src/features/midi/index.tsx
@@ -102,6 +102,13 @@ function parseMidiMessage(event: MIDIMessageEvent): MidiEvent | null {
 
   let status = data[0]
   let command = status >>> 4
+
+  // 0x8 = Note Off, 0x9 = Note On, 0xA = Polyphonic Aftertouch
+  // Only process note on/off messages, ignore aftertouch and other messages
+  if (command !== 0x8 && command !== 0x9) {
+    return null
+  }
+
   return {
     type: command === 0x9 ? 'on' : 'off',
     note: data[1],


### PR DESCRIPTION
Fixes issue where notes would randomly disappear while keys were held down on MIDI keyboards that send polyphonic aftertouch messages (e.g., Roli Piano M).

## Problem
The MIDI message parser was treating all non-0x9 (Note On) messages as Note Off, including 0xA (Polyphonic Aftertouch) messages. This caused aftertouch pressure updates to be misinterpreted as note release events, making notes randomly disappear while keys were still held down.

## Solution
The parser now explicitly filters for only 0x8 (Note Off) and 0x9 (Note On) messages, ignoring aftertouch and other MIDI messages.

## Testing
Tested with Roli Piano M keyboard - notes now stay visible for the entire duration that keys are held down, regardless of aftertouch messages.