### PR TITLE
fix: correct key signature handling in sheet music rendering

### DIFF
--- a/src/features/SongVisualization/sheet.ts
+++ b/src/features/SongVisualization/sheet.ts
@@ -312,9 +312,9 @@ function renderMidiPressedKeys(state: State, inRange: (SongNote | SongMeasure)[]
     }
 
     const staffTopY = staff === 'bass' ? getBassStaffTopY(state) : getTrebleStaffTopY(state)
-    const canvasY = getNoteY(note, staff, staffTopY)
+    const canvasY = getNoteY(note, staff, staffTopY, state.keySignature)
     let canvasX = getPlayNotesLineX(state) - 2
-    const key = getKey(note)
+    const key = getKey(note, state.keySignature)
     drawMusicNote(
       ctx,
       canvasX,
@@ -322,12 +322,13 @@ function renderMidiPressedKeys(state: State, inRange: (SongNote | SongMeasure)[]
       state.coloredNotes ? `rgba(${getNoteColor(true, key[0])},1)` : 'red',
     )
 
-    // is sharp
+    // Draw accidental (sharp or flat)
     if (key.length === 2) {
       const symbolColor = state.coloredNotes ? `rgba(${getNoteColor(true, key[0])},1)` : 'black'
+      const accidental = key[1] === '#' ? glyphs.accidentalSharp : glyphs.accidentalFlat
       drawSymbol(
         ctx,
-        glyphs.accidentalSharp,
+        accidental,
         canvasX - 24,
         canvasY,
         STAFF_FIVE_LINES_HEIGHT * 0.6,

--- a/src/features/theory/key-signature.ts
+++ b/src/features/theory/key-signature.ts
@@ -48,12 +48,12 @@ const keyToNotes: { [sig in KEY_SIGNATURE]: string[] } = {
 
   // Flats
   F: ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B', 'B♮'],
-  Bb: ['C', 'D♭', 'D', 'E', 'E♮', 'F', 'G♭', 'G', 'A♭', 'A', 'B', 'B♮'],
-  Eb: ['C', 'D♭', 'D', 'E', 'E♮', 'F', 'G♭', 'G', 'A', 'A♮', 'B', 'B♮'],
-  Ab: ['C', 'D', 'D♮', 'E', 'E♮', 'F', 'G♭', 'G', 'A', 'A♮', 'B', 'B♮'],
-  Db: ['C', 'D', 'D♮', 'E', 'E♮', 'F', 'G', 'G♮', 'A', 'A♮', 'B', 'B♮'],
-  Gb: ['C♮', 'D', 'D♮', 'E', 'E♮', 'F', 'G', 'G♮', 'A', 'A♮', 'B', 'C'],
-  Cb: ['C♮', 'D', 'D♮', 'E', 'E', 'F♮', 'G', 'G♮', 'A', 'A♮', 'B', 'C'],
+  Bb: ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
+  Eb: ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
+  Ab: ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
+  Db: ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
+  Gb: ['C♭', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
+  Cb: ['C♭', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B'],
 }
 
 let keyDetailsMap: KeyAlterationMap = getKeyDetailsMap()


### PR DESCRIPTION
Fixes incorrect note labels and positions when pressing MIDI keys in Sheet mode with flat key signatures (Db, Bb, Eb, Ab, Gb, Cb).

## Problem
When pressing MIDI keys in Sheet mode with a flat key signature (e.g., Db), the pressed notes would:
1. Display with incorrect accidental symbols (showing G# instead of Ab)
2. Appear at the wrong vertical position on the staff
3. Show different colors than the corresponding sheet music notes

## Root Cause
1. The `renderMidiPressedKeys()` function was calling `getNoteY()` and `getKey()` without passing the key signature parameter, causing them to default to C major
2. Flat key signature mappings in `key-signature.ts` were using natural symbols (E♮, A♮) instead of flat symbols (E♭, A♭)
3. Accidental rendering only handled sharps, not flats

## Solution
1. Pass `state.keySignature` parameter to both `getNoteY()` and `getKey()` function calls in `renderMidiPressedKeys()`
2. Fix flat key signature mappings to use proper flat symbols
3. Detect sharp vs flat in key and render the appropriate accidental symbol (`glyphs.accidentalSharp` vs `glyphs.accidentalFlat`)

## Testing
- Tested with Db major key signature
- MIDI pressed keys now correctly display as "Ab" and "F" matching the sheet music
- Notes appear at the correct vertical positions
- Accidentals show proper flat symbols (♭) instead of sharp symbols (♯)

## Before/After
**Before:** With Db key signature, pressing Ab on MIDI keyboard would show "G#" at the wrong vertical position with a different color  
**After:** Correctly shows "Ab" at the proper position matching the key signature and sheet music notes