### PR TITLE
feat: add colored notes combobox with Material Design colors

### DIFF
--- a/src/features/SongVisualization/canvas-renderer.ts
+++ b/src/features/SongVisualization/canvas-renderer.ts
@@ -1,5 +1,5 @@
 import { KEY_SIGNATURE, NOTE_LABELS } from '@/features/theory'
-import { Hand, HandSettings } from '@/types'
+import { ColoredNotesMode, Hand, HandSettings } from '@/types'
 import { Player } from '../player'
 import { renderFallingVis } from './falling-notes'
 import { renderSheetVis } from './sheet'
@@ -8,7 +8,7 @@ import { CanvasItem } from './utils'
 export type GivenState = {
   time: number
   noteLabels: NOTE_LABELS
-  coloredNotes: boolean
+  coloredNotes: ColoredNotesMode
   visualization: 'falling-notes' | 'sheet'
   windowWidth: number
   height: number

--- a/src/features/SongVisualization/falling-notes.ts
+++ b/src/features/SongVisualization/falling-notes.ts
@@ -7,7 +7,7 @@ import {
 } from '@/features/drawing/piano'
 import { getFixedDoNoteFromKey, getKey, isBlack } from '@/features/theory'
 import { palette } from '@/styles/common'
-import type { SongMeasure, SongNote } from '@/types'
+import type { ColoredNotesMode, SongMeasure, SongNote } from '@/types'
 import { clamp } from '@/utils'
 import midiState from '../midi'
 import { getRelativePointerCoordinates } from '../pointer'
@@ -34,6 +34,26 @@ const colors = {
   measure: 'rgb(60,60,60)',
   octaveLine: 'rgb(90,90,90)',
   rangeSelectionFill: '#44b22e',
+}
+
+const originalColoredNotesMap: { [step: string]: string } = {
+  A: 'rgb(12,23,141)',
+  B: 'rgb(75,32,139)',
+  C: 'rgb(217,59,38)',
+  D: 'rgb(238,151,56)',
+  E: 'rgb(253,229,65)',
+  F: 'rgb(62,139,38)',
+  G: 'rgb(139,210,250)',
+}
+
+const materialColoredNotesMap: { [step: string]: string } = {
+  C: 'rgb(244,67,54)',
+  D: 'rgb(255,152,0)',
+  E: 'rgb(255,235,59)',
+  F: 'rgb(76,175,80)',
+  G: 'rgb(0,188,212)',
+  A: 'rgb(33,150,243)',
+  B: 'rgb(156,39,176)',
 }
 
 /**
@@ -168,6 +188,16 @@ export function renderFallingVis(givenState: GivenState): void {
 }
 
 function getNoteColor(state: State, note: SongNote): string {
+  if (state.coloredNotes !== 'off') {
+    const key = getKey(note.midiNote, state.keySignature)
+    const step = key[0]
+    if (state.coloredNotes === 'original') {
+      return originalColoredNotesMap[step] || colors.right.white
+    } else {
+      return materialColoredNotesMap[step] || colors.right.white
+    }
+  }
+
   const hand = state.hands[note.track]?.hand ?? 'both'
   const keyType = isBlack(note.midiNote) ? 'black' : 'white'
 

--- a/src/features/SongVisualization/sheet.ts
+++ b/src/features/SongVisualization/sheet.ts
@@ -9,7 +9,7 @@ import {
   drawTimeSignature,
   STAFF_SPACE,
 } from '@/features/drawing'
-import { Clef, SongMeasure, SongNote } from '@/types'
+import { Clef, ColoredNotesMode, SongMeasure, SongNote } from '@/types'
 import { pickHex } from '@/utils'
 import {
   drawLedgerLines,
@@ -152,7 +152,7 @@ const colorMap = {
   black: '0,0,0',
 }
 
-const coloredNotesMap: { [step: string]: string } = {
+const originalColoredNotesMap: { [step: string]: string } = {
   A: '12,23,141',
   B: '75,32,139',
   C: '217,59,38',
@@ -160,6 +160,16 @@ const coloredNotesMap: { [step: string]: string } = {
   E: '253,229,65',
   F: '62,139,38',
   G: '139,210,250',
+}
+
+const materialColoredNotesMap: { [step: string]: string } = {
+  C: '244,67,54',
+  D: '255,152,0',
+  E: '255,235,59',
+  F: '76,175,80',
+  G: '0,188,212',
+  A: '33,150,243',
+  B: '156,39,176',
 }
 
 function getGameColorPrefix(state: State, note: SongNote, canvasX: number) {
@@ -351,6 +361,12 @@ function fadeColorToWhite(color: string, gradient: any) {
   gradient.addColorStop(1, `rgba(${color},1)`)
 }
 
-function getNoteColor(coloredNotes: boolean, step: string): string {
-  return coloredNotes ? coloredNotesMap[step] : colorMap.black
+function getNoteColor(coloredNotes: ColoredNotesMode, step: string): string {
+  if (coloredNotes === 'off') {
+    return colorMap.black
+  } else if (coloredNotes === 'original') {
+    return originalColoredNotesMap[step] || colorMap.black
+  } else {
+    return materialColoredNotesMap[step] || colorMap.black
+  }
 }

--- a/src/features/SongVisualization/utils.ts
+++ b/src/features/SongVisualization/utils.ts
@@ -64,7 +64,7 @@ export function getDefaultSongSettings(song?: Song): SongConfig {
     right: true,
     waiting: false,
     noteLabels: 'none',
-    coloredNotes: false,
+    coloredNotes: 'off',
     skipMissedNotes: false,
     visualization: 'falling-notes',
     tracks: {},

--- a/src/pages/play/components/SettingsPanel.tsx
+++ b/src/pages/play/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@ import { Toggle } from '@/components'
 import { AdjustInstruments } from '@/features/controls'
 import { getKeySignatures, KEY_SIGNATURE, NOTE_LABELS } from '@/features/theory'
 import { useEventListener, useWhenClickedOutside } from '@/hooks'
-import { Song, SongConfig, VisualizationMode } from '@/types'
+import { ColoredNotesMode, Song, SongConfig, VisualizationMode } from '@/types'
 import clsx from 'clsx'
 import React, { PropsWithChildren, useCallback, useRef, useState } from 'react'
 import BpmDisplay from './BpmDisplay'
@@ -51,8 +51,8 @@ export default function SettingsPanel(props: SidebarProps) {
   function handleNoteLabels(noteLabels: NOTE_LABELS) {
     props.onChange({ ...props.config, noteLabels })
   }
-  function handleColoredNotes() {
-    props.onChange({ ...props.config, coloredNotes: !coloredNotes })
+  function handleColoredNotes(coloredNotes: ColoredNotesMode) {
+    props.onChange({ ...props.config, coloredNotes })
   }
   function handleKeySignature(keySignature: KEY_SIGNATURE) {
     props.onChange({ ...props.config, keySignature })
@@ -112,9 +112,16 @@ export default function SettingsPanel(props: SidebarProps) {
             </div>
             <div className="flex justify-center">
               <span className="min-w-[18ch]">Colored notes</span>
-              <div className="flex w-[120px]">
-                <Toggle checked={coloredNotes} onChange={handleColoredNotes} />
-              </div>
+              <select
+                name="coloredNotes"
+                className="w-[120px] border bg-white"
+                value={coloredNotes}
+                onChange={(e) => handleColoredNotes(e.target.value as ColoredNotesMode)}
+              >
+                <option value="off">Off</option>
+                <option value="original">Original</option>
+                <option value="material">Material</option>
+              </select>
             </div>
             <div className="flex justify-center">
               <span className="min-w-[18ch]">Note Labels</span>

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,13 +85,14 @@ export type Song = {
 export type Clef = 'bass' | 'treble'
 export type VisualizationMode = 'falling-notes' | 'sheet'
 export type Hand = 'both' | 'left' | 'right' | 'none'
+export type ColoredNotesMode = 'off' | 'original' | 'material'
 export type SongConfig = {
   left: boolean
   right: boolean
   waiting: boolean
   visualization: VisualizationMode
   noteLabels: NOTE_LABELS
-  coloredNotes: boolean
+  coloredNotes: ColoredNotesMode
   skipMissedNotes: boolean
   keySignature?: KEY_SIGNATURE
   tracks: {


### PR DESCRIPTION
## Summary
Convert colored notes from boolean toggle to combobox with three options:
- **Off** (default): Uses hand-based colors (purple for right hand, orange for left hand)
- **Original**: Colors from original fork (PR #98)
- **Material**: Google Material Design 500 colors in rainbow order

## Changes
- Add `ColoredNotesMode` type: `'off' | 'original' | 'material'`
- Update `SongConfig.coloredNotes` from `boolean` to `ColoredNotesMode`
- Implement `originalColoredNotesMap` with colors from original fork
- Implement `materialColoredNotesMap` with Material Design 500 colors:
  - C: Red (#F44336), D: Orange (#FF9800), E: Yellow (#FFEB3B)
  - F: Green (#4CAF50), G: Cyan (#00BCD4)
  - A: Blue (#2196F3), B: Purple (#9C27B0)
- Replace Toggle UI component with Select dropdown in Settings Panel
- Support both falling-notes and sheet visualizations

## Test Plan
- [x] Test "Off" option - notes display with hand-based colors
- [x] Test "Original" option - notes display with original fork colors
- [x] Test "Material" option - notes display with Material Design colors
- [x] Test in falling-notes visualization
- [x] Test in sheet hero visualization
- [x] Verify dropdown UI works correctly
- [x] Verify setting persists across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)