### PR TITLE
Feat/variable asset router base

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,23 @@ bun install
 2. Run the development server
 
 ```
-bun run dev
+export VITE_PUBLIC_GA_ID=stub
+bun run dev --host
 ```
 
 3. Run the production build preview
 
 ```
 bun run build && bun run preview
+```
+
+Building for alternative paths (example)
+
+```
+VITE_PUBLIC_GA_ID=stub \
+VITE_PUBLIC_ASSET_BASE=/api/sightread/ \
+VITE_PUBLIC_ROUTER_BASENAME=/api/sightread \
+bun run build
 ```
 
 ## File & Folder Structure

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,6 +1,9 @@
 import type { Config } from '@react-router/dev/config'
 
+const routerBasename = process.env.VITE_PUBLIC_ROUTER_BASENAME || "/";
+
 export default {
   appDirectory: 'src/pages',
   ssr: false, // enable SPA mode
+  basename: routerBasename, // tell React Router the base URL
 } satisfies Config

--- a/src/features/SongVisualization/images.ts
+++ b/src/features/SongVisualization/images.ts
@@ -1,8 +1,12 @@
+import { assetUrl } from '@/utils/assets'
+
 export type ImageLoader = (src: string) => Promise<HTMLImageElement>
 
 let loadImage: ImageLoader = (src: string) => {
   const img = new Image()
-  img.src = src
+  // Map relative paths like "images/black-key-raised.png"
+  // to the correct asset base (e.g. /sightread/images/...)
+  img.src = assetUrl(src)
   return new Promise((resolve, reject) => {
     img.onload = () => resolve(img)
     img.onerror = () => reject(img)
@@ -27,8 +31,8 @@ export function waitForImages(): Promise<void> {
   if (!imagesReadyPromise) {
     imagesReadyPromise = (async () => {
       const [blackKeyRaised, blackKeyPressed] = await Promise.all([
-        loadImage('/images/black-key-raised.png'),
-        loadImage('/images/black-key-pressed.png'),
+        loadImage('images/black-key-raised.png'),
+        loadImage('images/black-key-pressed.png'),
       ])
       images = { blackKeyRaised, blackKeyPressed }
     })()

--- a/src/features/data/index.tsx
+++ b/src/features/data/index.tsx
@@ -4,13 +4,14 @@ import { base64ToBytes, peek } from '@/utils'
 import type { SWRResponse } from 'swr'
 import useSWRImmutable from 'swr/immutable'
 import * as persistence from '../persist/persistence'
+import { assetUrl } from '@/utils/assets'
 
 async function handleSong(response: Response): Promise<Song> {
   return response.arrayBuffer().then((buf) => parseMidi(new Uint8Array(buf)))
 }
 
 function getBuiltinSongUrl(id: string) {
-  return `/music/songs/${id}`
+  return assetUrl(`music/songs/${id}`)
 }
 
 function getBase64Song(data: string): Song {

--- a/src/features/theory/procedural.ts
+++ b/src/features/theory/procedural.ts
@@ -1,5 +1,6 @@
 import { Clef, Song, SongMeasure, SongNote } from '@/types'
 import { Deferred } from '@/utils'
+import { assetUrl } from '@/utils/assets'
 import { parseMidi } from '../parsers'
 import { getRandomNote } from './key-signature'
 
@@ -190,14 +191,14 @@ async function getMeasuresForChord(
   clef: Clef,
 ): Promise<Measure[]> {
   const chordAndHighOrLow = irishMidiFiles[chord]
-  let filename = `/music/irish/Right Hand/${chordAndHighOrLow}_Lvl_${level}.mid`
+  let url = assetUrl(`music/irish/Right Hand/${chordAndHighOrLow}_Lvl_${level}.mid`)
   if (clef === 'bass') {
     const chord = chordAndHighOrLow.slice(0, chordAndHighOrLow.indexOf('_'))
     const bassLevel = Math.min(2, level)
-    filename = `/music/irish/Left Hand/${chord.toString()}_Lvl_${bassLevel}_LH.mid`
+    url = assetUrl(`music/irish/Left Hand/${chord.toString()}_Lvl_${bassLevel}_LH.mid`)
   }
 
-  return fetch(filename)
+  return fetch(url)
     .then((r) => r.arrayBuffer())
     .then((buffer) => parseMidi(new Uint8Array(buffer)))
     .then(splitMeasures)
@@ -227,7 +228,7 @@ type ChordProgression = 'eMinor' | 'dMajor' | 'random'
 
 async function getBackingTrack(type: ChordProgression): Promise<HTMLAudioElement> {
   const filename = randomChoice(type === 'eMinor' ? eMinorBackingTracks : dMajorBackingTracks)!
-  const url = `/music/irish/Backing Tracks/${filename}`
+  const url = assetUrl(`music/irish/Backing Tracks/${filename}`)
   const track = new Audio(url)
   const deferred: Deferred<HTMLAudioElement> = new Deferred()
   track.addEventListener('canplaythrough', () => deferred.resolve(track))

--- a/src/pages/about/page.tsx
+++ b/src/pages/about/page.tsx
@@ -1,4 +1,5 @@
 import { AppBar, MarketingFooter, Sizer } from '@/components'
+import { assetUrl } from '@/utils/assets'
 import React, { PropsWithChildren } from 'react'
 import { Link, LinkProps } from 'react-router'
 import manifest from './../../manifest.json'
@@ -85,7 +86,7 @@ function WhatSection() {
       </p>
       <Sizer height={8} />
       <CaptionedImage
-        src="/images/mode_falling_notes_screenshot.png"
+        src={assetUrl('images/mode_falling_notes_screenshot.png')}
         caption="Falling Notes with note labels"
         height={1628}
         width={1636}
@@ -103,7 +104,7 @@ function WhatSection() {
       </p>
       <Sizer height={8} />
       <CaptionedImage
-        src="/images/mode_sheet_hero_screenshot.png"
+        src={assetUrl('images/mode_sheet_hero_screenshot.png')}
         width={1980}
         height={1148}
         caption="Sheet Hero (beta) with note labels"

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -1,9 +1,13 @@
 import { GA_TRACKING_ID } from '@/features/analytics'
+import { assetUrl } from '@/utils/assets'
 import styles from '@/styles/global.css?inline'
 import { Outlet, Scripts, ScrollRestoration } from 'react-router'
 import { Providers } from './providers'
 
 export function Layout({ children }: { children: React.ReactNode }) {
+  const ogImageUrl = assetUrl('images/mode_falling_notes_screenshot.png')
+  const faviconUrl = assetUrl('favicon.ico')
+
   return (
     <html lang="en">
       <head>
@@ -18,7 +22,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta property="og:title" content="Sightread" />
         <meta property="og:site_name" content="Sightread" />
         <meta property="og:description" content="app for learning piano" />
-        <meta property="og:image" content="/images/mode_falling_notes_screenshot.png" />
+        <meta property="og:image" content={ogImageUrl} />
         <meta
           property="og:image:alt"
           content="Sightread demo displaying falling notes visualization"
@@ -28,6 +32,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="twitter:card" content="summary_large_image" />
         <meta
           name="twitter:image"
+          // Keep the public, absolute URL for social sharing
           content="https://sightread.dev/images/mode_falling_notes_screenshot.png"
         />
         <meta
@@ -36,8 +41,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
 
         {/* Favicons */}
-        <link rel="icon" href="/favicon.ico" />
-        <link rel="apple-touch-icon" href="/favicon.ico" />
+        <link rel="icon" href={faviconUrl} />
+        <link rel="apple-touch-icon" href={faviconUrl} />
 
         {/* Global Site Tag (gtag.js) - Google Analytics */}
         <script defer src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />

--- a/src/pages/training/sound-effects.ts
+++ b/src/pages/training/sound-effects.ts
@@ -1,8 +1,9 @@
 import { isBrowser } from '@/utils'
+import { assetUrl } from '@/utils/assets'
 
 let failSound: HTMLAudioElement | null = null
 if (isBrowser()) {
-  failSound = new Audio('/effects/wrong-sound-effect.mp3')
+  failSound = new Audio(assetUrl('effects/wrong-sound-effect.mp3'))
   failSound.playbackRate = 6
   failSound.volume = 0.08
 }

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -1,0 +1,15 @@
+const ASSET_BASE: string =
+  (import.meta.env.VITE_PUBLIC_ASSET_BASE as string | undefined) ??
+  (import.meta.env.BASE_URL as string | undefined) ??
+  '/';
+
+/**
+ * Build a URL under the configured asset base, avoiding duplicate slashes.
+ * Example: assetUrl('music/songs/ode-to-joy.mid') ->
+ *   '/sightread/music/songs/ode-to-joy.mid' when ASSET_BASE='/sightread/'.
+ */
+export function assetUrl(path: string): string {
+  const base = ASSET_BASE.replace(/\/+$/, '/');
+  const normalizedPath = path.replace(/^\/+/, '');
+  return base + normalizedPath;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,15 @@ import { defineConfig } from 'vite'
 import devtoolsJson from 'vite-plugin-devtools-json'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
+const assetBase = process.env.VITE_PUBLIC_ASSET_BASE || '/'
+const routerBasename = process.env.VITE_PUBLIC_ROUTER_BASENAME || '/'
+
 export default defineConfig({
-  plugins: [devtoolsJson(), tailwindcss(), reactRouter(), tsconfigPaths()],
+  base: assetBase,
+  plugins: [
+    devtoolsJson(),
+    tailwindcss(),
+    reactRouter(),
+    tsconfigPaths()
+  ],
 })


### PR DESCRIPTION
- respect VITE_PUBLIC_ASSET_BASE/VITE_PUBLIC_ROUTER_BASENAME in Vite and React Router configs
- add assetUrl helper and apply it across assets, metadata, audio, and generated/procedural fetches
- update docs with the new environment variables and build instructions