### PR TITLE
Fix/Local song title (filename) not showing

### DIFF
--- a/src/features/data/library.tsx
+++ b/src/features/data/library.tsx
@@ -14,7 +14,7 @@ const builtinMetadata: Array<[string, SongMetadata]> = Object.values(builtinSong
 const builtinMetadataAtom = atom(builtinMetadata)
 const storageMetadataAtom = atom((get) => {
   const songs = Array.from(get(localSongsAtom).values()).flatMap((x) => x)
-  return songs.map((x) => [x.id, x]) as [string, SongMetadata][]
+  return songs.map((x) => [getKey(x.id, x.source), x]) as [string, SongMetadata][]
 })
 
 export const songManifestAtom = atom<Map<string, SongMetadata>>((get) => {


### PR DESCRIPTION
The issue was that local media source songs were being stored in the song manifest map with an inconsistent key format: Before: Local songs used x.id as the map key (e.g., "uuid/song.mid") Lookup: Was trying to find "local/uuid/song.mid"
Result: Mismatch → no metadata found → no title displayed After the fix: Local songs now use getKey(x.id, x.source) which creates the key "local/uuid/song.mid", matching the lookup format and allowing the title to be retrieved correctly. 

Song titles for local media source files now appear in the upper right corner of the player.